### PR TITLE
fix, nits: `Unable to access Earthquake Monitor` Card overflow 

### DIFF
--- a/lib/app/page/map/monitor/monitor.dart
+++ b/lib/app/page/map/monitor/monitor.dart
@@ -1219,9 +1219,12 @@ class _MonitorPageState extends State<MonitorPage> with SingleTickerProviderStat
               child: _buildLegend(),
             ),
           if (_showMonitorInfo)
-            Positioned(
-              right: 6,
-              top: 75,
+            Padding(
+              padding: const EdgeInsets.only(
+                top: 75,
+                left: 6,
+                right: 6,
+              ),
               child: Card(
                 elevation: 4,
                 child: Padding(


### PR DESCRIPTION
## 這是什麼類型的 PR？

- [ ] 重構
- [ ] 新功能
- [x] 錯誤修復 (Bugfix)
- [ ] 最佳化
- [ ] 技術文件更新

## 描述 (Description)

- The "Unable to access Earthquake Monitor" card was overflowing on some mobile devices.
  - This was caused by the Stack->Positioned tree structure. It has been changed to Stack->Padding for better user experience.


## 相關 issue

- None

## QA 指南、截圖、錄像

- Tested on iPhone 14 Pro, iOS 18.0, JP

| Before | After |
| --- | --- | 
|![IMG_2136](https://github.com/user-attachments/assets/8b2421c9-ce1c-45ff-b867-0d35a0a93884)|![IMG_2134](https://github.com/user-attachments/assets/635403c6-f1b4-4c46-b27f-9c7f62abb16a)|

### UI 無障礙清單


- [ ] 變數名稱實現語意化命名？
- [ ] 測試通過 AA 顏色對比？


---

Contacts: 
- X: [`@YumNumm`](https://x.com/YumNumm)
- Mail: `admin[at]yumnumm.dev`