### PR TITLE
Fix monitor replay not showing RTS data (dev)

### DIFF
--- a/lib/models/data.dart
+++ b/lib/models/data.dart
@@ -170,6 +170,13 @@ class DpipDataModel extends _DpipDataModel {
     return UnmodifiableListView(_eew.where((eew) => eew.info.time >= threeMinutesAgo).toList());
   }
 
+  /// Sets the RTS (Real-Time Shaking) data if it's newer than the current data.
+  ///
+  /// In replay mode, filters out RTS data that is more than 1 second ahead
+  /// of the current replay timestamp to maintain temporal consistency and
+  /// prevent displaying future data during replay.
+  ///
+  /// @param rts The new RTS data to set
   void setRts(Rts rts) {
     final incoming = rts.time;
 
@@ -187,9 +194,11 @@ class DpipDataModel extends _DpipDataModel {
   void setReplayMode(bool isReplay, [int? timestamp]) {
     _isReplayMode = isReplay;
     if (isReplay) {
-      assert(timestamp != null, 'Timestamp must be provided in replay mode');
+      if (timestamp == null) {
+        throw ArgumentError('Timestamp must be provided in replay mode');
+      }
       _replayTimestamp = timestamp;
-      _rtsTime = (timestamp ?? DateTime.now().millisecondsSinceEpoch) - 1;
+      _rtsTime = timestamp - 1;
     } else {
       _replayTimestamp = null;
       _rtsTime = 0;


### PR DESCRIPTION
<!--
  如果是正在進行中的 Pull Request，請使用草稿 PR 功能，
  詳情請參見：https://github.blog/2019-02-14-introducing-draft-pull-requests/

  為了能更即時地審核/回應，請避免強制推送其他 commit 至已經收到 Review 的 PR。

  在提交 Pull Request 之前，請確保您已完成以下事項：
  - 👷‍♀️ 在大多數情況下，建立小型的 PR 是可以的。
  - ✅ 為您的更改提供測試。
  - 📝 使用具有描述性的 commit 訊息。
  - 📗 更新相關技術文件並包含相關截圖。
-->

## 這是什麼類型的 PR？

> 選擇所有符合的項目

- [ ] 重構
- [ ] 新功能
- [x] 錯誤修復
- [ ] 最佳化
- [ ] 技術文件更新

## 描述

修復開啟 replay 功能時無法顯示 rts 資料

## 相關 issue

<!--
對於與某個問題相關或關閉某個問題的 Pull Request，請在下方註記它們。
我們遵循 Github 的 [將問題鏈接到 Pull Request](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) 指南。

例如，「closes #1234」將把目前的 PR 與 issue#1234 連接起來。
當我們合併 PR 時，Github 就會自動關閉對應的 issue 。
-->

- 相關問題 #
- closes #

## QA 指南、截圖、錄像

> _請將這行替換成：如何測試您的 PR 的步驟，已測試的裝置註釋，以及任何相關的 UI 更改圖片。_

### UI 無障礙清單

> _如果您的 PR 包含 UI 更改，請使用此清單：_

- [ ] 變數名稱實現語意化命名？
- [ ] 測試通過 AA 顏色對比？
