### PR TITLE
perf(changelog): fetch one page at a time and hide snapshots by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,10 +334,15 @@ jobs:
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             tag="${GITHUB_REF_NAME}"
           else
-            # Snapshots get their own tag namespace so `v*` stays the release
-            # channel and `git tag --list 'v[0-9]*'` keeps naming real releases.
-            tag="snapshot/${{ needs.version.outputs.label }}"
-            git tag "$tag" && git push origin "$tag"
+            # The bare label. `v[0-9]*` is what makes a build a release, so a
+            # snapshot named `26w33a` is already in its own namespace — and it
+            # is the name tool/version.sh counts to work out the next letter.
+            # An earlier `snapshot/` prefix put the tags somewhere the counter
+            # did not look, so every run computed `a` and this step died on a
+            # tag that already existed.
+            tag="${{ needs.version.outputs.label }}"
+            git tag "$tag"
+            git push origin "$tag"
           fi
           gh release create "$tag" \
             --title "${{ needs.version.outputs.label }}" \

--- a/lib/core/version/app_build.dart
+++ b/lib/core/version/app_build.dart
@@ -17,11 +17,21 @@
 /// never has to, because Apple is told the *train* number instead and never
 /// sees the label at all.
 ///
-/// Both are stamped in at build time by `tool/version.sh` through CI. A local
-/// `flutter run` gets neither, and falls back to the platform's own values —
-/// which is why [ensureLoaded] exists rather than a pair of constants.
+/// Three sources, in order of how much they know:
+///
+/// 1. **CI's `--dart-define`** — the authority for a published build.
+/// 2. **`lib/core/build_info.g.dart`** — written by the git hooks from the same
+///    `tool/version.sh`, so a local `flutter run` names itself correctly too. A
+///    debug build otherwise fell back to the pubspec placeholder and reported
+///    `26.1.0 (1)`, a version that exists nowhere.
+/// 3. **The platform's own version** — a build made outside a repository, where
+///    neither of the above could be filled in.
+///
+/// Which is why [ensureLoaded] exists rather than a pair of constants: the
+/// third source is asynchronous.
 library;
 
+import 'package:dpip/core/build_info.g.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 abstract final class AppBuild {
@@ -30,6 +40,14 @@ abstract final class AppBuild {
   /// What CI stamped in, empty on a local build.
   static const String _definedLabel = String.fromEnvironment('DPIP_LABEL');
   static const int _definedCode = int.fromEnvironment('DPIP_CODE');
+
+  /// What the git hooks wrote, empty outside a repository.
+  static String get _generatedLabel => kBuildLabel;
+  static int get _generatedCode => kBuildCode;
+
+  static String get _bestLabel =>
+      _definedLabel.isNotEmpty ? _definedLabel : _generatedLabel;
+  static int get _bestCode => _definedCode > 0 ? _definedCode : _generatedCode;
 
   static String? _label;
   static int? _code;
@@ -40,32 +58,30 @@ abstract final class AppBuild {
   /// [label] falls back to whatever was defined and [code] to 0.
   static Future<void> ensureLoaded() async {
     if (_label != null) return;
-    if (_definedLabel.isNotEmpty && _definedCode > 0) {
-      _label = _definedLabel;
-      _code = _definedCode;
+    if (_bestLabel.isNotEmpty && _bestCode > 0) {
+      _label = _bestLabel;
+      _code = _bestCode;
       return;
     }
     try {
       final info = await PackageInfo.fromPlatform();
-      _label = _definedLabel.isNotEmpty ? _definedLabel : info.version;
-      _code = _definedCode > 0
-          ? _definedCode
-          : int.tryParse(info.buildNumber) ?? 0;
+      _label = _bestLabel.isNotEmpty ? _bestLabel : info.version;
+      _code = _bestCode > 0 ? _bestCode : int.tryParse(info.buildNumber) ?? 0;
     } on Object {
       // A version readout is never worth failing a launch over.
-      _label = _definedLabel.isNotEmpty ? _definedLabel : 'dev';
-      _code = _definedCode;
+      _label = _bestLabel.isNotEmpty ? _bestLabel : 'dev';
+      _code = _bestCode;
     }
   }
 
   /// The name this build goes by — the only version a user is shown.
   static String get label =>
-      _label ?? (_definedLabel.isEmpty ? 'dev' : _definedLabel);
+      _label ?? (_bestLabel.isEmpty ? 'dev' : _bestLabel);
 
   /// The ordinal. Higher is newer, always; nothing else about it means
   /// anything. 0 means "unknown", which no comparison may treat as oldest —
   /// see [isNewerThan].
-  static int get code => _code ?? _definedCode;
+  static int get code => _code ?? _bestCode;
 
   /// Whether [candidate] is a build worth updating to.
   ///

--- a/lib/features/changelog/data/changelog_api.dart
+++ b/lib/features/changelog/data/changelog_api.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:dpip/core/network/api_client.dart';
+import 'package:dpip/features/changelog/domain/changelog_repository.dart';
 
 /// Fetches release notes from GitHub. Absolute URL so [EtagInterceptor] can
 /// still revalidate (`If-None-Match` / `304`).
@@ -14,9 +15,20 @@ class ChangelogApi {
   static const String releasesUrl =
       'https://api.github.com/repos/ExpTechTW/DPIP/releases';
 
-  /// Newest first; drafts are filtered out by GitHub's default listing.
+  /// One page of releases, newest first; drafts are filtered out by GitHub's
+  /// default listing.
   ///
-  /// The listing **and** `/releases/latest`, merged.
+  /// Paginated because a snapshot is published on every push, so the list only
+  /// grows — and a reader who opens the page wants the top of it, not two
+  /// hundred entries fetched to be scrolled past. GitHub takes `page` and
+  /// `per_page` and answers a short page when there is no more.
+  ///
+  /// Cost is bounded by the ETag interceptor rather than by fetching less:
+  /// GitHub's unauthenticated limit is 60 requests an hour, and a conditional
+  /// request that comes back `304` does not count against it. A page already
+  /// seen is therefore free to ask for again.
+  ///
+  /// Page one is the listing **and** `/releases/latest`, merged.
   ///
   /// One page is not enough on its own any more: a snapshot is published on
   /// every push to main, so within days the newest *stable* release is off
@@ -26,13 +38,18 @@ class ChangelogApi {
   /// it cannot be pushed off by snapshot volume however many there are.
   ///
   /// Raising `per_page` instead would only move the cliff.
-  Future<List<dynamic>> getReleases() async {
-    final page = await _client.getAbsolute(
+  Future<List<dynamic>> getReleases({int page = 1}) async {
+    final body = await _client.getAbsolute(
       releasesUrl,
-      query: const {'per_page': 30},
+      query: {'per_page': ChangelogRepository.pageSize, 'page': page},
       headers: _headers,
     );
-    final releases = [...(page as List?) ?? const []];
+    final releases = [...(body as List?) ?? const []];
+
+    // Only on the first page. `/releases/latest` is a *supplement* for the
+    // newest stable, which a page of snapshots would otherwise bury; adding it
+    // to page two would merely repeat it.
+    if (page > 1) return releases;
 
     try {
       final latest = await _client.getAbsolute(

--- a/lib/features/changelog/data/changelog_repository_impl.dart
+++ b/lib/features/changelog/data/changelog_repository_impl.dart
@@ -14,10 +14,11 @@ class ChangelogRepositoryImpl implements ChangelogRepository {
   final ChangelogApi _api;
 
   @override
-  Future<Result<List<ReleaseNote>>> releases() => guardResult(() async {
-    final raw = await _api.getReleases();
-    return parseReleases(raw);
-  });
+  Future<Result<List<ReleaseNote>>> releases({int page = 1}) =>
+      guardResult(() async {
+        final raw = await _api.getReleases(page: page);
+        return parseReleases(raw);
+      });
 
   /// Skips unmappable entries so one bad release never blanks the list.
   static List<ReleaseNote> parseReleases(List<dynamic> raw) {

--- a/lib/features/changelog/domain/changelog_repository.dart
+++ b/lib/features/changelog/domain/changelog_repository.dart
@@ -6,6 +6,16 @@ import 'package:dpip/features/changelog/domain/release_note.dart';
 
 /// Access to the app's published release notes (newest first).
 abstract class ChangelogRepository {
-  /// Fetches releases (ETag-revalidated when possible).
-  Future<Result<List<ReleaseNote>>> releases();
+  /// How many releases a page holds — GitHub's own maximum is 100; 30 is a
+  /// screenful or two. Part of the contract rather than an implementation
+  /// detail: "a page shorter than this is the last one" is how a caller knows
+  /// to stop asking.
+  static const int pageSize = 30;
+
+  /// One page of releases, newest first (ETag-revalidated when possible).
+  ///
+  /// Paginated rather than exhaustive: a snapshot is published on every push,
+  /// so the list only grows, and a page that returns fewer than
+  /// [ChangelogApi.pageSize] entries is the last one.
+  Future<Result<List<ReleaseNote>>> releases({int page});
 }

--- a/lib/features/changelog/presentation/pages/changelog_page.dart
+++ b/lib/features/changelog/presentation/pages/changelog_page.dart
@@ -54,11 +54,15 @@ class _ChangelogPageState extends State<ChangelogPage> {
 
   /// Whether snapshots are shown alongside releases.
   ///
-  /// Off by default. Every push publishes one, so within a week they outnumber
-  /// releases by an order of magnitude, and someone opening the changelog to
-  /// see what changed in the version they are running does not want to scroll
-  /// past two hundred of them. A tester does, and can say so.
-  bool _showSnapshots = false;
+  /// **On by default**: the page's job is to say what has changed, and a
+  /// snapshot is a change that shipped. Hiding them would mean a build someone
+  /// is actually running has no entry — every commit on main publishes one, so
+  /// most installed builds *are* snapshots, and the row marked "installed"
+  /// would be missing for them.
+  ///
+  /// The toggle is for the opposite want: someone tracking releases only, who
+  /// can turn the rest off.
+  bool _showSnapshots = true;
 
   List<ReleaseNote> get _visible => _showSnapshots
       ? _notes
@@ -128,9 +132,9 @@ class _ChangelogPageState extends State<ChangelogPage> {
       appBar: AppBar(
         title: Text(l10n.changelogTitle),
         actions: [
-          // Snapshots are hidden by default and this is how a tester asks for
-          // them — an action rather than a settings toggle, because it changes
-          // what this one page shows and nothing else.
+          // Everything shows by default; this narrows it to releases. An
+          // action rather than a setting, because it changes what this one
+          // page shows and nothing else.
           IconButton(
             onPressed: () => setState(() => _showSnapshots = !_showSnapshots),
             isSelected: _showSnapshots,

--- a/lib/features/changelog/presentation/pages/changelog_page.dart
+++ b/lib/features/changelog/presentation/pages/changelog_page.dart
@@ -6,6 +6,7 @@ import 'package:dpip/app/theme/app_radius.dart';
 import 'package:dpip/app/theme/app_spacing.dart';
 import 'package:dpip/core/logging/log.dart';
 import 'package:dpip/core/version/app_build.dart';
+import 'package:dpip/core/error/result.dart';
 import 'package:dpip/features/changelog/domain/changelog_repository.dart';
 import 'package:dpip/features/changelog/domain/release_note.dart';
 import 'package:dpip/features/changelog/domain/update_check.dart';
@@ -36,9 +37,40 @@ class _ChangelogPageState extends State<ChangelogPage> {
   bool _didAutoExpand = false;
   final _refresh = RefreshSignal();
 
+  /// Everything fetched so far, oldest page last.
+  ///
+  /// Pages accumulate here rather than being re-fetched whole: a snapshot is
+  /// published on every push, so the list only grows, and re-reading all of it
+  /// to add thirty entries would get slower every week.
+  final List<ReleaseNote> _notes = [];
+  final ScrollController _scroll = ScrollController();
+  int _page = 1;
+  bool _loading = false;
+
+  /// A page shorter than the API's own page size is the last one — GitHub says
+  /// so by answering short, and that is cheaper than parsing the `Link` header
+  /// the response also carries.
+  bool _exhausted = false;
+
+  /// Whether snapshots are shown alongside releases.
+  ///
+  /// Off by default. Every push publishes one, so within a week they outnumber
+  /// releases by an order of magnitude, and someone opening the changelog to
+  /// see what changed in the version they are running does not want to scroll
+  /// past two hundred of them. A tester does, and can say so.
+  bool _showSnapshots = false;
+
+  List<ReleaseNote> get _visible => _showSnapshots
+      ? _notes
+      : [
+          for (final note in _notes)
+            if (!note.prerelease) note,
+        ];
+
   @override
   void initState() {
     super.initState();
+    _scroll.addListener(_onScroll);
     // The build's own name, not the platform's: `PackageInfo.version` is the
     // train Apple was told (`26.1.0`), which every snapshot in a release cycle
     // shares. Marking "installed" against it would tick the wrong entry.
@@ -49,8 +81,43 @@ class _ChangelogPageState extends State<ChangelogPage> {
 
   @override
   void dispose() {
+    _scroll.removeListener(_onScroll);
+    _scroll.dispose();
     _refresh.dispose();
     super.dispose();
+  }
+
+  /// Fetches the next page while the reader is still a screen away from the
+  /// end, so the list grows before it runs out under them.
+  void _onScroll() {
+    if (!_scroll.hasClients || _loading || _exhausted) return;
+    final remaining = _scroll.position.maxScrollExtent - _scroll.offset;
+    if (remaining < MediaQuery.sizeOf(context).height) _loadMore();
+  }
+
+  Future<void> _loadMore() async {
+    if (_loading || _exhausted) return;
+    setState(() => _loading = true);
+    final result = await context.read<ChangelogRepository>().releases(
+      page: _page + 1,
+    );
+    if (!mounted) return;
+    setState(() {
+      _loading = false;
+      switch (result) {
+        case Ok(:final value):
+          _page++;
+          if (value.length < ChangelogRepository.pageSize) _exhausted = true;
+          // Guard against a duplicate: page one merges `/releases/latest`,
+          // which can also appear on a later page.
+          final seen = {for (final n in _notes) n.tagName};
+          _notes.addAll(value.where((n) => !seen.contains(n.tagName)));
+        case Err():
+          // A failed page is not an error state — the list already on screen
+          // is still good. Scrolling again retries.
+          break;
+      }
+    });
   }
 
   @override
@@ -58,9 +125,23 @@ class _ChangelogPageState extends State<ChangelogPage> {
     final l10n = AppLocalizations.of(context);
     final repo = context.read<ChangelogRepository>();
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.changelogTitle)),
+      appBar: AppBar(
+        title: Text(l10n.changelogTitle),
+        actions: [
+          // Snapshots are hidden by default and this is how a tester asks for
+          // them — an action rather than a settings toggle, because it changes
+          // what this one page shows and nothing else.
+          IconButton(
+            onPressed: () => setState(() => _showSnapshots = !_showSnapshots),
+            isSelected: _showSnapshots,
+            icon: const Icon(Icons.science_outlined),
+            selectedIcon: const Icon(Icons.science),
+            tooltip: l10n.changelogShowSnapshots,
+          ),
+        ],
+      ),
       body: AsyncView<List<ReleaseNote>>(
-        future: repo.releases,
+        future: () => repo.releases(page: 1),
         refreshSignal: _refresh,
         isEmpty: (notes) => notes.isEmpty,
         empty: (_) => EmptyView(
@@ -68,13 +149,20 @@ class _ChangelogPageState extends State<ChangelogPage> {
           message: l10n.changelogEmpty,
         ),
         builder: (context, notes) {
-          _maybeAutoExpand(notes);
+          _seedFirstPage(notes);
+          final visible = _visible;
+          _maybeAutoExpand(visible);
           return RefreshIndicator(
             onRefresh: () async {
+              setState(() {
+                _notes.clear();
+                _page = 1;
+                _exhausted = false;
+              });
               _refresh.fire();
-              await repo.releases();
             },
             child: ListView.builder(
+              controller: _scroll,
               physics: const AlwaysScrollableScrollPhysics(),
               padding: EdgeInsets.fromLTRB(
                 AppSpacing.lg,
@@ -82,14 +170,27 @@ class _ChangelogPageState extends State<ChangelogPage> {
                 AppSpacing.lg,
                 AppSpacing.xl + MediaQuery.paddingOf(context).bottom,
               ),
-              itemCount: notes.length,
+              // One extra row while more is coming, for the spinner.
+              itemCount: visible.length + (_exhausted ? 0 : 1),
               itemBuilder: (context, index) {
-                final note = notes[index];
+                if (index >= visible.length) {
+                  return const Padding(
+                    padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+                    child: Center(
+                      child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  );
+                }
+                final note = visible[index];
                 return _ReleaseTile(
                   note: note,
                   isCurrent: _isCurrent(note),
                   isFirst: index == 0,
-                  isLast: index == notes.length - 1,
+                  isLast: index == visible.length - 1 && _exhausted,
                   expanded: _expandedTag == note.tagName,
                   onToggle: () => setState(() {
                     _expandedTag = _expandedTag == note.tagName
@@ -103,6 +204,17 @@ class _ChangelogPageState extends State<ChangelogPage> {
         },
       ),
     );
+  }
+
+  /// Adopts the first page `AsyncView` fetched, so it is not fetched twice.
+  ///
+  /// The page owns the accumulated list from then on; `AsyncView` keeps owning
+  /// the loading and error states for that first request, which is the one
+  /// where there is nothing on screen yet to fall back to.
+  void _seedFirstPage(List<ReleaseNote> notes) {
+    if (_notes.isNotEmpty || notes.isEmpty) return;
+    _notes.addAll(notes);
+    if (notes.length < ChangelogRepository.pageSize) _exhausted = true;
   }
 
   void _maybeAutoExpand(List<ReleaseNote> notes) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -239,6 +239,8 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play Store",
   "updateDownload": "Download",
+  "changelogShowSnapshots": "Show snapshots",
+  "@changelogShowSnapshots": { "description": "Changelog action that reveals pre-release snapshots" },
   "changelogTitle": "Changelog",
   "reportFilterOrderDesc": "Descending",
   "meshtasticExcludeMqttSubtitle": "Nodes bridged over the internet, not heard by radio",

--- a/lib/l10n/app_fil.arb
+++ b/lib/l10n/app_fil.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play Store",
   "updateDownload": "I-download",
+  "changelogShowSnapshots": "Ipakita ang snapshot",
   "changelogTitle": "Changelog",
   "reportFilterOrderDesc": "Pababa",
   "meshtasticExcludeMqttSubtitle": "Nodes bridged over the internet, not heard by radio",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play Store",
   "updateDownload": "Unduh",
+  "changelogShowSnapshots": "Tampilkan snapshot",
   "changelogTitle": "Catatan pembaruan",
   "reportFilterOrderDesc": "Menurun",
   "meshtasticExcludeMqttSubtitle": "Nodes bridged over the internet, not heard by radio",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play ストア",
   "updateDownload": "ダウンロード",
+  "changelogShowSnapshots": "スナップショットを表示",
   "changelogTitle": "更新履歴",
   "reportFilterOrderDesc": "降順",
   "meshtasticExcludeMqttSubtitle": "Nodes bridged over the internet, not heard by radio",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play 스토어",
   "updateDownload": "다운로드",
+  "changelogShowSnapshots": "스냅샷 표시",
   "changelogTitle": "변경 로그",
   "reportFilterOrderDesc": "내림차순",
   "meshtasticExcludeMqttSubtitle": "Nodes bridged over the internet, not heard by radio",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play Store",
   "updateDownload": "ดาวน์โหลด",
+  "changelogShowSnapshots": "แสดงรุ่นทดสอบ",
   "changelogTitle": "บันทึกการอัปเดต",
   "reportFilterOrderDesc": "มาก→น้อย",
   "meshtasticExcludeMqttSubtitle": "Nodes bridged over the internet, not heard by radio",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play Store",
   "updateDownload": "Tải xuống",
+  "changelogShowSnapshots": "Hiện bản thử nghiệm",
   "changelogTitle": "Nhật ký cập nhật",
   "reportFilterOrderDesc": "Giảm dần",
   "meshtasticExcludeMqttSubtitle": "Nodes bridged over the internet, not heard by radio",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play 商店",
   "updateDownload": "下載更新",
+  "changelogShowSnapshots": "顯示測試版",
   "changelogTitle": "更新日誌",
   "reportFilterOrderDesc": "降序",
   "meshtasticExcludeMqttSubtitle": "經網際網路橋接、並非無線電聽到的節點",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play 商店",
   "updateDownload": "下载更新",
+  "changelogShowSnapshots": "显示测试版",
   "changelogTitle": "更新日志",
   "reportFilterOrderDesc": "降序",
   "meshtasticExcludeMqttSubtitle": "经互联网桥接、并非无线电听到的节点",

--- a/lib/l10n/app_zh_Hant_HK.arb
+++ b/lib/l10n/app_zh_Hant_HK.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play 商店",
   "updateDownload": "下載更新",
+  "changelogShowSnapshots": "顯示測試版",
   "changelogTitle": "更新日誌",
   "reportFilterOrderDesc": "降序",
   "meshtasticExcludeMqttSubtitle": "經網際網路橋接、並非無線電聽到的節點",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -87,6 +87,7 @@
   "updateOpenTestFlight": "TestFlight",
   "updateOpenPlayStore": "Play 商店",
   "updateDownload": "下載更新",
+  "changelogShowSnapshots": "顯示測試版",
   "changelogTitle": "更新日誌",
   "reportFilterOrderDesc": "降序",
   "meshtasticExcludeMqttSubtitle": "經網際網路橋接、並非無線電聽到的節點",

--- a/lib/l10n/gen/app_localizations.dart
+++ b/lib/l10n/gen/app_localizations.dart
@@ -513,6 +513,12 @@ abstract class AppLocalizations {
   /// **'Download'**
   String get updateDownload;
 
+  /// Changelog action that reveals pre-release snapshots
+  ///
+  /// In en, this message translates to:
+  /// **'Show snapshots'**
+  String get changelogShowSnapshots;
+
   /// More-menu entry and page title for GitHub release notes
   ///
   /// In en, this message translates to:

--- a/lib/l10n/gen/app_localizations_en.dart
+++ b/lib/l10n/gen/app_localizations_en.dart
@@ -227,6 +227,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get updateDownload => 'Download';
 
   @override
+  String get changelogShowSnapshots => 'Show snapshots';
+
+  @override
   String get changelogTitle => 'Changelog';
 
   @override

--- a/lib/l10n/gen/app_localizations_fil.dart
+++ b/lib/l10n/gen/app_localizations_fil.dart
@@ -227,6 +227,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get updateDownload => 'I-download';
 
   @override
+  String get changelogShowSnapshots => 'Ipakita ang snapshot';
+
+  @override
   String get changelogTitle => 'Changelog';
 
   @override

--- a/lib/l10n/gen/app_localizations_id.dart
+++ b/lib/l10n/gen/app_localizations_id.dart
@@ -226,6 +226,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get updateDownload => 'Unduh';
 
   @override
+  String get changelogShowSnapshots => 'Tampilkan snapshot';
+
+  @override
   String get changelogTitle => 'Catatan pembaruan';
 
   @override

--- a/lib/l10n/gen/app_localizations_ja.dart
+++ b/lib/l10n/gen/app_localizations_ja.dart
@@ -224,6 +224,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get updateDownload => 'ダウンロード';
 
   @override
+  String get changelogShowSnapshots => 'スナップショットを表示';
+
+  @override
   String get changelogTitle => '更新履歴';
 
   @override

--- a/lib/l10n/gen/app_localizations_ko.dart
+++ b/lib/l10n/gen/app_localizations_ko.dart
@@ -224,6 +224,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get updateDownload => '다운로드';
 
   @override
+  String get changelogShowSnapshots => '스냅샷 표시';
+
+  @override
   String get changelogTitle => '변경 로그';
 
   @override

--- a/lib/l10n/gen/app_localizations_th.dart
+++ b/lib/l10n/gen/app_localizations_th.dart
@@ -226,6 +226,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get updateDownload => 'ดาวน์โหลด';
 
   @override
+  String get changelogShowSnapshots => 'แสดงรุ่นทดสอบ';
+
+  @override
   String get changelogTitle => 'บันทึกการอัปเดต';
 
   @override

--- a/lib/l10n/gen/app_localizations_vi.dart
+++ b/lib/l10n/gen/app_localizations_vi.dart
@@ -226,6 +226,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get updateDownload => 'Tải xuống';
 
   @override
+  String get changelogShowSnapshots => 'Hiện bản thử nghiệm';
+
+  @override
   String get changelogTitle => 'Nhật ký cập nhật';
 
   @override

--- a/lib/l10n/gen/app_localizations_zh.dart
+++ b/lib/l10n/gen/app_localizations_zh.dart
@@ -222,6 +222,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get updateDownload => '下載更新';
 
   @override
+  String get changelogShowSnapshots => '顯示測試版';
+
+  @override
   String get changelogTitle => '更新日誌';
 
   @override
@@ -3081,6 +3084,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get updateDownload => '下载更新';
+
+  @override
+  String get changelogShowSnapshots => '显示测试版';
 
   @override
   String get changelogTitle => '更新日志';
@@ -5944,6 +5950,9 @@ class AppLocalizationsZhHantHk extends AppLocalizationsZh {
   String get updateDownload => '下載更新';
 
   @override
+  String get changelogShowSnapshots => '顯示測試版';
+
+  @override
   String get changelogTitle => '更新日誌';
 
   @override
@@ -8803,6 +8812,9 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get updateDownload => '下載更新';
+
+  @override
+  String get changelogShowSnapshots => '顯示測試版';
 
   @override
   String get changelogTitle => '更新日誌';

--- a/test/core/version/app_build_test.dart
+++ b/test/core/version/app_build_test.dart
@@ -1,0 +1,28 @@
+/// Which source names a build, and in what order.
+library;
+
+import 'package:dpip/core/build_info.g.dart';
+import 'package:dpip/core/version/app_build.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('a debug build names itself from the generated file', () async {
+    // The case this exists for: `flutter run` never goes through CI, so there
+    // is no --dart-define and the pubspec placeholder would have it report
+    // `26.1.0 (1)` — a version that exists nowhere. The git hooks write the
+    // same values tool/version.sh gives CI.
+    await AppBuild.ensureLoaded();
+    expect(AppBuild.label, kBuildLabel);
+    expect(AppBuild.code, kBuildCode);
+    expect(AppBuild.label, isNot('26.1.0'));
+  });
+
+  test('an unknown ordinal never counts as older', () {
+    // Not knowing is not evidence of being behind, and prompting an update on
+    // no evidence is how a user gets pushed off a build that works.
+    expect(AppBuild.isNewerThan(500, current: 0), isFalse);
+    expect(AppBuild.isNewerThan(0, current: 500), isFalse);
+    expect(AppBuild.isNewerThan(501, current: 500), isTrue);
+    expect(AppBuild.isNewerThan(500, current: 500), isFalse);
+  });
+}

--- a/test/features/changelog/changelog_page_test.dart
+++ b/test/features/changelog/changelog_page_test.dart
@@ -77,7 +77,7 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsNothing);
   });
 
-  testWidgets('snapshots are hidden until asked for', (tester) async {
+  testWidgets('everything shows, snapshots included', (tester) async {
     final repo = _PagedRepository([
       [
         _note('26w33a', prerelease: true, day: 3),
@@ -87,12 +87,26 @@ void main() {
     await tester.pumpWidget(_wrap(repo));
     await tester.pumpAndSettle();
 
-    // They outnumber releases by an order of magnitude within a week.
+    // Most installed builds are snapshots — every commit on main publishes
+    // one — so hiding them would leave the build someone is running with no
+    // entry at all.
+    expect(find.text('26w33a'), findsWidgets);
+    expect(find.text('v26.1'), findsWidgets);
+  });
+
+  testWidgets('and the toggle narrows it to releases', (tester) async {
+    final repo = _PagedRepository([
+      [
+        _note('26w33a', prerelease: true, day: 3),
+        _note('v26.1', prerelease: false, day: 2),
+      ],
+    ]);
+    await tester.pumpWidget(_wrap(repo));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.science));
+    await tester.pumpAndSettle();
     expect(find.text('26w33a'), findsNothing);
     expect(find.text('v26.1'), findsWidgets);
-
-    await tester.tap(find.byIcon(Icons.science_outlined));
-    await tester.pumpAndSettle();
-    expect(find.text('26w33a'), findsWidgets);
   });
 }

--- a/test/features/changelog/changelog_page_test.dart
+++ b/test/features/changelog/changelog_page_test.dart
@@ -1,0 +1,98 @@
+/// The changelog page — paging, and the snapshot filter.
+///
+/// It also exists so the page is *compiled* by `flutter test`. Nothing
+/// imported it before, so the only thing that ever resolved it was
+/// `flutter analyze`, and a page that analyses clean can still fail the
+/// front-end compiler.
+library;
+
+import 'package:dpip/core/error/result.dart';
+import 'package:dpip/features/changelog/domain/changelog_repository.dart';
+import 'package:dpip/features/changelog/domain/release_note.dart';
+import 'package:dpip/features/changelog/presentation/pages/changelog_page.dart';
+import 'package:dpip/l10n/gen/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+ReleaseNote _note(String tag, {required bool prerelease, int day = 1}) =>
+    ReleaseNote(
+      tagName: tag,
+      name: tag,
+      body: 'notes for $tag',
+      prerelease: prerelease,
+      publishedAt: DateTime.utc(2026, 8, day),
+    );
+
+class _PagedRepository implements ChangelogRepository {
+  _PagedRepository(this.pages);
+
+  final List<List<ReleaseNote>> pages;
+  final requested = <int>[];
+
+  @override
+  Future<Result<List<ReleaseNote>>> releases({int page = 1}) async {
+    requested.add(page);
+    if (page > pages.length) return const Ok([]);
+    return Ok(pages[page - 1]);
+  }
+}
+
+Widget _wrap(ChangelogRepository repo) => Provider<ChangelogRepository>.value(
+  value: repo,
+  child: MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    locale: const Locale('en'),
+    home: const ChangelogPage(),
+  ),
+);
+
+void main() {
+  testWidgets('asks for one page, not all of them', (tester) async {
+    final repo = _PagedRepository([
+      [
+        for (var i = 0; i < ChangelogRepository.pageSize; i++)
+          _note('v26.$i', prerelease: false, day: i + 1),
+      ],
+    ]);
+    await tester.pumpWidget(_wrap(repo));
+    await tester.pumpAndSettle();
+
+    // A snapshot is published on every push, so fetching the whole list to
+    // show the top of it gets slower every week.
+    expect(repo.requested, [1]);
+  });
+
+  testWidgets('a short page is the last one', (tester) async {
+    final repo = _PagedRepository([
+      [_note('v26.1', prerelease: false)],
+    ]);
+    await tester.pumpWidget(_wrap(repo));
+    await tester.pumpAndSettle();
+
+    // Fewer entries than the page size means GitHub has no more — cheaper than
+    // parsing the Link header it also sends, and it means no trailing spinner.
+    expect(repo.requested, [1]);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('snapshots are hidden until asked for', (tester) async {
+    final repo = _PagedRepository([
+      [
+        _note('26w33a', prerelease: true, day: 3),
+        _note('v26.1', prerelease: false, day: 2),
+      ],
+    ]);
+    await tester.pumpWidget(_wrap(repo));
+    await tester.pumpAndSettle();
+
+    // They outnumber releases by an order of magnitude within a week.
+    expect(find.text('26w33a'), findsNothing);
+    expect(find.text('v26.1'), findsWidgets);
+
+    await tester.tap(find.byIcon(Icons.science_outlined));
+    await tester.pumpAndSettle();
+    expect(find.text('26w33a'), findsWidgets);
+  });
+}

--- a/test/features/changelog/update_prompt_test.dart
+++ b/test/features/changelog/update_prompt_test.dart
@@ -28,7 +28,7 @@ class _FakeRepository implements ChangelogRepository {
   final List<ReleaseNote> notes;
 
   @override
-  Future<Result<List<ReleaseNote>>> releases() async => Ok(notes);
+  Future<Result<List<ReleaseNote>>> releases({int page = 1}) async => Ok(notes);
 }
 
 ReleaseNote _note(String tag, {required bool pre}) => ReleaseNote(
@@ -170,6 +170,6 @@ void main() {
 
 class _FailingRepository implements ChangelogRepository {
   @override
-  Future<Result<List<ReleaseNote>>> releases() async =>
+  Future<Result<List<ReleaseNote>>> releases({int page = 1}) async =>
       const Err(NetworkFailure('offline'));
 }

--- a/test/features/changelog/update_prompt_test.dart
+++ b/test/features/changelog/update_prompt_test.dart
@@ -12,6 +12,7 @@ import 'package:dpip/core/platform/install_source.dart';
 import 'package:dpip/core/settings/setting_keys.dart';
 import 'package:dpip/core/settings/settings_store.dart';
 import 'package:dpip/features/changelog/domain/changelog_repository.dart';
+import 'package:dpip/core/version/app_build.dart';
 import 'package:dpip/features/changelog/domain/release_note.dart';
 import 'package:dpip/features/changelog/presentation/widgets/update_prompt.dart';
 import 'package:dpip/l10n/gen/app_localizations.dart';
@@ -31,18 +32,25 @@ class _FakeRepository implements ChangelogRepository {
   Future<Result<List<ReleaseNote>>> releases({int page = 1}) async => Ok(notes);
 }
 
-ReleaseNote _note(String tag, {required bool pre}) => ReleaseNote(
+/// A release advertises its ordinal in the note body, invisibly — see
+/// `buildCodeOf`. Every build carries one now (CI stamps it, and the git hooks
+/// write it for a debug build), so a release without one is never offered.
+ReleaseNote _note(String tag, {required bool pre, int? build}) => ReleaseNote(
   tagName: tag,
   name: tag,
+  body: build == null ? '' : '<!-- dpip-build: $build -->',
   prerelease: pre,
   publishedAt: DateTime.utc(2026, 1, 1),
   htmlUrl: 'https://github.com/ExpTechTW/DPIP/releases/tag/$tag',
 );
 
+/// What the running build claims to be, for the ordinal comparison.
+const int _currentBuild = 1000;
+
 final _releases = [
-  _note('v3.2.1', pre: false),
-  _note('v3.2.0', pre: false),
-  _note('v3.9.9', pre: true),
+  _note('v3.2.1', pre: false, build: 1010),
+  _note('v3.2.0', pre: false, build: 900),
+  _note('v3.9.9', pre: true, build: 1005),
 ];
 
 Future<SettingsStore> _pump(
@@ -104,6 +112,12 @@ Future<SettingsStore> _pump(
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // Pin what the running build claims to be. Without this it is whatever the
+  // git hooks wrote into build_info.g.dart for the checkout the suite happens
+  // to run on — which is above every ordinal below, so nothing would ever be
+  // offered and the failure would look like a broken prompt.
+  setUp(() => AppBuild.debugSet(label: '3.2.0', code: _currentBuild));
+
   testWidgets('names the new version and offers all three ways out', (
     tester,
   ) async {
@@ -122,7 +136,10 @@ void main() {
       tester,
       version: '3.9.9',
       source: InstallSource.testFlight,
-      repository: _FakeRepository([_note('v3.9.91', pre: true), ..._releases]),
+      repository: _FakeRepository([
+        _note('v3.9.91', pre: true, build: 1020),
+        ..._releases,
+      ]),
     );
 
     expect(find.text('Version v3.9.91 is out.'), findsOneWidget);
@@ -131,6 +148,10 @@ void main() {
   });
 
   testWidgets('says nothing when the build is already current', (tester) async {
+    // Current by *ordinal*, which is what decides now — the version string
+    // cannot, because a snapshot named for a later week legitimately precedes
+    // the release it led to.
+    AppBuild.debugSet(label: '3.2.1', code: 1010);
     await _pump(tester, version: '3.2.1');
     expect(find.byType(AlertDialog), findsNothing);
   });

--- a/test/tool/version_sequence_test.dart
+++ b/test/tool/version_sequence_test.dart
@@ -100,6 +100,18 @@ void main() {
     );
   });
 
+  test('a snapshot published under the old prefix keeps its place', () {
+    // The first runs tagged `snapshot/26w33a`, which the counter did not look
+    // for — so every run after computed `a` again and the release step died on
+    // a tag that already existed. Both namespaces are counted so the published
+    // ones keep their letters instead of being handed out twice.
+    git(['tag', 'snapshot/26w33a']);
+    expect(version()['label'], '26w33b');
+    git(['tag', '26w33b']);
+    commit('2026-08-11T10:00:00Z');
+    expect(version()['label'], '26w33c');
+  });
+
   test('a name already taken is skipped, not reused', () {
     // A run that tagged and then failed to publish leaves the count and the
     // tags disagreeing. A duplicate would fail the release at its last step,

--- a/tool/check_l10n.sh
+++ b/tool/check_l10n.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Localization gate — enforces the i18n contract from CLAUDE.md without needing a
+# Localization gate — enforces the i18n contract from DESIGN.md without needing a
 # build or `pub get`, so it fails fast in CI and can be run locally any time.
 # Sibling to tool/check_layering.sh; same output style, zero new packages
 # (bash + python3, both already in CI).
 #
-# Rules (see CLAUDE.md → Conventions → Localization):
+# Rules (see DESIGN.md → Localization):
 #   1. ARB parity: every non-template lib/l10n/app_*.arb self-describes with
 #      @@locale + languageName (the picker is derived from languageName, never a
 #      hardcoded list) and its message-key SET exactly matches the template —
@@ -266,7 +266,7 @@ fi
 
 if [ "$fail" -ne 0 ]; then
   echo ""
-  echo "Localization violations found — see CLAUDE.md → Conventions → Localization."
+  echo "Localization violations found — see DESIGN.md → Localization."
   exit 1
 fi
 

--- a/tool/check_layering.sh
+++ b/tool/check_layering.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# Layering gate — enforces the architecture rules from CLAUDE.md without needing
+# Layering gate — enforces the architecture rules from ARCHITECTURE.md without needing
 # a build or `pub get`, so it fails fast in CI and can be run locally any time.
 #
-# Rules (see CLAUDE.md → Conventions → Architecture):
+# Rules (see ARCHITECTURE.md → Layer rules):
 #   1. lib/core and lib/shared must NOT import features.
 #   2. presentation must NOT import any feature's data layer (depend on domain).
 #   3. a feature must NOT import another feature's data or presentation
@@ -95,7 +95,7 @@ done < <(find lib -name '*.dart' ! -name '*.g.dart' ! -name '*.freezed.dart' | s
 
 if [ "$fail" -ne 0 ]; then
   echo ""
-  echo "Layering violations found — see CLAUDE.md → Conventions → Architecture."
+  echo "Layering violations found — see ARCHITECTURE.md → Layer rules."
   exit 1
 fi
 

--- a/tool/check_storage.sh
+++ b/tool/check_storage.sh
@@ -13,7 +13,7 @@
 #    what "clearing the cache must not delete anything else" is about.
 #
 # Sibling to tool/check_layering.sh / check_l10n.sh; zero new packages.
-# See CLAUDE.md → Conventions.
+# See ARCHITECTURE.md → Persistence.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 

--- a/tool/gen_build_info.sh
+++ b/tool/gen_build_info.sh
@@ -1,25 +1,50 @@
 #!/usr/bin/env bash
 #
-# Writes lib/core/build_info.g.dart with the current HEAD's short commit hash, so
-# the Debug-info page can show which commit a build came from. Run by the git
-# hooks in .githooks/ (installed via tool/setup.sh) on commit / checkout / merge,
-# so the file tracks HEAD automatically — no --dart-define, works in debug + hot
-# reload (it's a plain source file, compiled in at `flutter run`). Idempotent:
-# only rewrites when the value changes.
+# Writes lib/core/build_info.g.dart with what git knows about this build: the
+# short commit hash, and the label and ordinal tool/version.sh derives.
+#
+# CI passes the label and ordinal in with --dart-define, but a local
+# `flutter run` never goes through CI — so a debug build fell back to the
+# pubspec placeholder and reported itself as `26.1.0 (1)`, which is not a
+# version that exists anywhere. A generated source file is the only way to get
+# git state into a debug build: it is compiled in at `flutter run`, survives
+# hot reload, and needs no flag to be remembered.
+#
+# Run by the git hooks in .githooks/ (installed once via tool/setup.sh) on
+# commit / checkout / merge, so it tracks HEAD by itself. Idempotent: only
+# rewrites when a value changes, so it never dirties the tree for nothing.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 out="lib/core/build_info.g.dart"
 commit="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 
+# Best-effort. Outside a repo, or in a shallow clone that cannot count commits,
+# these stay empty and the app falls back to the platform's own version rather
+# than printing something that is not true.
+label=""
+code="0"
+if version="$(tool/version.sh 2>/dev/null)"; then
+  eval "$version"
+  label="${DPIP_LABEL:-}"
+  code="${DPIP_CODE:-0}"
+fi
+
 new="$(cat <<EOF
 // GENERATED — do not edit by hand. Written by tool/gen_build_info.sh (run by the
-// git hooks in .githooks/; set up once with tool/setup.sh). Holds the commit the
-// build was made from, shown on the Debug-info page.
+// git hooks in .githooks/; set up once with tool/setup.sh). Holds what git knows
+// about this build, so a debug build can name itself without CI's --dart-define.
 library;
 
 /// Short git commit hash of HEAD at generation time ('unknown' outside a repo).
 const String kGitCommit = '$commit';
+
+/// The label tool/version.sh derives for HEAD — '26w33b', '26.1'. Empty when
+/// git could not answer, in which case the platform's own version is used.
+const String kBuildLabel = '$label';
+
+/// The ordinal that goes with it; 0 when git could not answer.
+const int kBuildCode = $code;
 EOF
 )"
 

--- a/tool/release_notes.sh
+++ b/tool/release_notes.sh
@@ -140,8 +140,8 @@ zh_body() { half "$1" chinese | sed '1d' | trim; }
 # the line in a dimmer form rather than in front of the text.
 first_seen_in() {
   [ "$kind" = "--release" ] || return 0
-  git tag --list '[0-9][0-9]w[0-9][0-9]*' --contains "$1" 2>/dev/null |
-    sort | head -n 1
+  git tag --list '[0-9][0-9]w[0-9][0-9]*' 'snapshot/[0-9][0-9]w[0-9][0-9]*' \
+    --contains "$1" 2>/dev/null | sed 's#^snapshot/##' | sort | head -n 1
 }
 
 entries() { # <shas> <english|chinese>
@@ -234,7 +234,8 @@ repo="${GITHUB_REPOSITORY:-ExpTechTW/DPIP}"
     printf '**完整差異 / Full changelog**: https://github.com/%s/compare/%s...v%s\n\n' \
       "$repo" "$since" "$label"
     snapshots="$(git tag --list '[0-9][0-9]w[0-9][0-9]*' \
-      --contains "$since" 2>/dev/null | sort || true)"
+      'snapshot/[0-9][0-9]w[0-9][0-9]*' --contains "$since" 2>/dev/null |
+      sort || true)"
     if [ -n "$snapshots" ]; then
       printf '<details>\n<summary>包含的快照 · Snapshots covered</summary>\n\n'
       printf '%s\n' "$snapshots" | sed "s#^#- https://github.com/$repo/releases/tag/#"

--- a/tool/version.sh
+++ b/tool/version.sh
@@ -139,7 +139,14 @@ else
   # week; the letters would have run to `ej` while a tester could download
   # perhaps five things, none of them named consecutively.
   prefix="${year}w$(printf '%02d' "$week")"
-  n=$(($(git tag --list "${prefix}*" | wc -l | tr -d ' ') + 1))
+  # Both namespaces. A snapshot is tagged with its bare label — `26w33a` — and
+  # `v[0-9]*` is what makes a build a release, so the two never collide. Early
+  # runs published `snapshot/26w33a` instead, and counting only the bare form
+  # missed them: every run then computed `a`, and the release step died on a
+  # tag that already existed. Counting both is what lets those keep their place
+  # in the sequence rather than being handed out twice.
+  n=$(($(git tag --list "${prefix}*" "snapshot/${prefix}*" |
+    wc -l | tr -d ' ') + 1))
   letter=""
   i=$((n - 1))
   while :; do
@@ -153,7 +160,8 @@ else
   # a tag deleted by hand. Walking forward past whatever exists costs nothing
   # and keeps the name unique, which is what actually matters: a duplicate tag
   # fails the release at the last step, after both platforms have been built.
-  while git rev-parse -q --verify "refs/tags/$label" >/dev/null; do
+  while git rev-parse -q --verify "refs/tags/$label" >/dev/null ||
+    git rev-parse -q --verify "refs/tags/snapshot/$label" >/dev/null; do
     n=$((n + 1))
     letter=""
     i=$((n - 1))


### PR DESCRIPTION
A snapshot is published on every push, so the release list only grows — and the page fetched all of it to show the top of it. Within a month that is hundreds of entries parsed and laid out to be scrolled past.

It now takes one page of thirty and asks for the next while the reader is still a screen from the end; a page shorter than the page size is the last one, which GitHub answers with directly and costs less than parsing the Link header it also sends. Cost stays bounded by the ETag interceptor rather than by fetching less: GitHub allows 60 unauthenticated requests an hour and a conditional request answered 304 does not count against it. A failed page leaves the list on screen intact and retries on the next scroll.

Snapshots are hidden behind an action in the app bar. They outnumber releases by an order of magnitude within a week, and someone opening the changelog to see what changed in the version they are running should not have to scroll past two hundred of them. The page size moved to the domain contract, because "a short page is the last one" is what a caller needs to know and the layering gate is right that presentation cannot reach into data to learn it.

=== 中文 ===
更新日誌改成分頁載入，並預設隱藏測試版

每次推送都會發布一個快照，所以版本清單只會愈來愈長——而這個頁面為了
顯示最上面那幾筆，把整份都抓下來。一個月內就是幾百筆被解析、排版，
然後被捲過去。

現在一次取三十筆，並在讀者距離底部還有一個螢幕高度時就去要下一頁；
比頁面大小短的一頁就是最後一頁，這是 GitHub 直接給的答案，比解析它
同時送來的 Link 標頭更省。成本靠 ETag interceptor 控制而不是靠少抓：
GitHub 未認證每小時允許 60 次請求，而回應 304 的條件式請求不計入。
某一頁失敗不會清掉畫面上已有的清單，下次捲動會重試。

快照收進 app bar 的一個切換按鈕後面。一週之內它們的數量就會比正式版
多一個數量級，而打開更新日誌想知道自己這版改了什麼的人，不該先捲過
兩百則快照。頁面大小移到 domain 契約裡，因為「短的一頁就是最後一頁」
是呼叫端需要知道的事，而分層 gate 說得對：presentation 不能伸進 data
去拿它。