### PR TITLE
test: fix the two tests that only failed on Linux

### DIFF
--- a/test/features/meshtastic/mesh_chat_controller_test.dart
+++ b/test/features/meshtastic/mesh_chat_controller_test.dart
@@ -61,6 +61,23 @@ void main() {
   Future<void> settle() =>
       Future<void>.delayed(const Duration(milliseconds: 150));
 
+  /// Waits until [store] holds [expected] messages.
+  ///
+  /// `_add` writes fire-and-forget and only adopts a message into the in-memory
+  /// list once the insert answers (mesh_chat_controller.dart:322-328), so both
+  /// halves of what these tests assert land *after* the controller has been
+  /// handed the packet. A fixed delay is therefore a guess about how fast the
+  /// machine is: 150 ms was enough on a laptop and not on CI, where the last
+  /// dozen inserts arrived after the test had already closed the database and
+  /// the failure read as `This database has already been closed`.
+  Future<void> drained(MeshStore store, int expected) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    while (DateTime.now().isBefore(deadline)) {
+      if ((await store.messages(limit: 100000)).length >= expected) return;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+  }
+
   test('keeps the newest messages first', () async {
     final (controller, service, _) = await makeController();
     for (var i = 0; i < 10; i++) {
@@ -78,7 +95,7 @@ void main() {
     for (var i = 0; i < MeshChatController.windowSize + 20; i++) {
       service.messages.add(message('m$i', seconds: i));
     }
-    await settle();
+    await drained(store, MeshChatController.windowSize + 20);
 
     expect(controller.messages, hasLength(MeshChatController.windowSize));
     // The store keeps everything — the window is a view, not a retention cap.
@@ -91,7 +108,7 @@ void main() {
   test('persists the log and reloads it after a restart', () async {
     final (controller, service, store) = await makeController();
     service.messages.add(message('hello'));
-    await settle();
+    await drained(store, 1);
     controller.dispose();
 
     final (restored, _, _) = await makeController(store);

--- a/test/tool/colorize_logs_test.dart
+++ b/test/tool/colorize_logs_test.dart
@@ -15,17 +15,21 @@ const _esc = 27;
 /// Runs the script over [input]. Without a pty, stdout is not a terminal.
 String run(String input, {bool tty = false}) {
   final script = '${Directory.current.path}/tool/internal/colorize_logs.sh';
+  final piped = 'printf %s ${_quote(input)} | $script';
+  // `script` lends the pipeline a pty, which is the only way to exercise the
+  // branch that decides whether to emit anything at all — and its argument
+  // order is the opposite on the two platforms this repository builds on.
+  // BSD takes the typescript file first and the command after it; util-linux
+  // wants the command behind `-c` and the file last. Written for BSD only, it
+  // passed on a laptop and hung Linux CI into a failure with no message.
   final result = tty
-      // `script` lends the pipeline a pty, which is the only way to exercise
-      // the branch that decides whether to emit anything at all.
-      ? Process.runSync('script', [
-          '-q',
-          '/dev/null',
-          'bash',
-          '-c',
-          'printf %s ${_quote(input)} | $script',
-        ])
-      : Process.runSync('bash', ['-c', 'printf %s ${_quote(input)} | $script']);
+      ? Process.runSync(
+          'script',
+          Platform.isMacOS
+              ? ['-q', '/dev/null', 'bash', '-c', piped]
+              : ['-q', '-c', piped, '/dev/null'],
+        )
+      : Process.runSync('bash', ['-c', piped]);
   expect(result.exitCode, 0, reason: result.stderr.toString());
   return result.stdout.toString();
 }

--- a/tool/commit.sh
+++ b/tool/commit.sh
@@ -301,7 +301,13 @@ if ((run_gates)); then
   note 'inputs, so an unchanged tree costs seconds instead of a minute.'
   printf '\n'
   if tool/check.sh; then
-    ok 'every gate passed — this is what CI will do'
+    ok "every gate passed, on $(uname -s)"
+    # Said, because the difference has already cost a red CI: this runs CI's
+    # command list on *this* machine, and the runner is Linux. A test that
+    # shells out meets a different sed, a different awk and a different
+    # `script`, and passes here while failing there.
+    [[ "$(uname -s)" == Linux ]] ||
+      note 'CI runs Linux — a test that shells out can still differ there'
   else
     block 'a gate failed — CI will fail the same way'
   fi


### PR DESCRIPTION
Both passed on every laptop and failed on every runner, which is the shape of bug the pre-push gate cannot see: it runs CI's command list on this machine, not on CI's machine.

`script` lends the colouriser a pty so the "is this a terminal" branch can be exercised at all, and its argument order is reversed between the platforms this repository builds on: BSD takes the typescript file first and the command after it, util-linux wants the command behind `-c` and the file last. Written for BSD only, it turned into a failure with no message on Linux.

The mesh window test slept 150 ms and then asserted. `_add` writes fire-and-forget and only adopts a message once the insert answers, so both halves of what the test checks land after the packet is handed over — a fixed delay is a guess about how fast the machine is. It waits for the store now. The tail of a 320-message burst was arriving after the test had closed the database, which reported as `This database has already been closed` thirteen times and then a length mismatch.

`tool/commit.sh` stops claiming "this is what CI will do" and names the platform it actually checked.

<!--
  進行中的 PR 請開草稿（Draft）。

  收到 review 之後請避免 force push，否則審查者看不到你改了什麼。

  送出之前跑 `tool/commit.sh --push` —— CI 跑的就是同一份，在本機失敗比在 CI
  失敗快得多，而且 `.githooks/pre-push` 本來就會替你跑一次。

  **這份描述不會被任何 gate 檢查，也不會進 main。** 被檢查的是分支上每一則
  commit 訊息，進 main 的也是它們 —— 這個 repo 只開放 rebase 合併。所以要寫給
  未來的人看的東西，寫在 commit 訊息裡，不是這裡。
-->

## 這個 PR 做了什麼

<!-- 一句話講清楚。細節寫在 commit 訊息裡，不要寫在這裡。 -->

## 相關 issue

<!-- 「closes #1234」會在合併時自動關閉對應的 issue。 -->

- closes #

## 怎麼驗

<!--
  審查者要怎麼確認這是對的：重現步驟、測過的裝置、UI 變更的前後截圖。

  如果碰到安全關鍵的部分（EEW 推估、警報門檻、通知路徑、背景定位），
  請額外說明你怎麼確認它沒有壞。
-->

## 檢查清單

- [ ] `tool/check/commits.sh origin/main..HEAD` 通過
      —— commit 訊息就是更新日誌，格式見 [commit.md](../commit.md)
- [ ] **一個 commit 一件事**（這條 gate 驗不了，靠自己和 review）
- [ ] `mise exec -- flutter analyze` 與 `mise exec -- flutter test` 通過
- [ ] 新的使用者可見字串都走 `AppLocalizations`，沒有寫死
- [ ] 有 UI 變更的話：用的是 `AppSpacing` / `AppRadius` / `AppMotion`，
      深色模式看過，文字對比度可接受
