### PR TITLE
ci(release): stop waiting for TestFlight with an expired token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,6 +296,20 @@ jobs:
           issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
           api-key-id: ${{ secrets.APPSTORE_API_KEY_ID }}
           api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+          # The upload finishes; the wait after it cannot. The action signs one
+          # App Store Connect JWT with a 600-second life (`n=600` in its bundled
+          # dist/index.js) and never re-signs it, while its own poll schedule
+          # sleeps 60 + 120 + 240 + 300 = 720 seconds before giving up. Any build
+          # that takes longer than the token lives reports
+          # `401 NOT_AUTHORIZED` — after the binary is already on TestFlight.
+          #
+          # Nothing here needs the wait: it exists so the action can write
+          # metadata afterwards, and this step sets neither `release-notes` nor
+          # `uses-non-exempt-encryption` — Info.plist already declares
+          # ITSAppUsesNonExemptEncryption. What is given up is being told when
+          # Apple rejects a binary during processing, which this step never told
+          # us anyway: it failed on the token whether processing passed or not.
+          wait-for-processing: 'false'
 
       # An Admin credential for the whole App Store Connect account. The runner
       # is ephemeral, but removing it costs one line.


### PR DESCRIPTION
The upload succeeded and the step failed anyway. `apple-actions/upload-testflight-build@v5` signs one App Store Connect JWT with a 600-second life — `n=600` in its bundled dist/index.js, with no re-signing anywhere in it — and then polls for the build to become visible on a schedule that sleeps 60 + 120 + 240 + 300 = 720 seconds before giving up. The token is guaranteed to die first, so any build Apple takes more than a few minutes to process reports 401 NOT_AUTHORIZED with the binary already delivered. Build 426000342 is on TestFlight; the run is red.

The wait is only there so the action can write metadata afterwards, and this step asks for none: it sets neither release-notes nor uses-non-exempt-encryption, and Info.plist already declares ITSAppUsesNonExemptEncryption.

What is given up is being told when Apple rejects a binary during processing. That signal was already gone — the step failed on the expired token whether processing passed or not, so the red said nothing about the build either way.

<!--
  進行中的 PR 請開草稿（Draft）。

  收到 review 之後請避免 force push，否則審查者看不到你改了什麼。

  送出之前跑 `tool/commit.sh --push` —— CI 跑的就是同一份，在本機失敗比在 CI
  失敗快得多，而且 `.githooks/pre-push` 本來就會替你跑一次。

  **這份描述不會被任何 gate 檢查，也不會進 main。** 被檢查的是分支上每一則
  commit 訊息，進 main 的也是它們 —— 這個 repo 只開放 rebase 合併。所以要寫給
  未來的人看的東西，寫在 commit 訊息裡，不是這裡。
-->

## 這個 PR 做了什麼

<!-- 一句話講清楚。細節寫在 commit 訊息裡，不要寫在這裡。 -->

## 相關 issue

<!-- 「closes #1234」會在合併時自動關閉對應的 issue。 -->

- closes #

## 怎麼驗

<!--
  審查者要怎麼確認這是對的：重現步驟、測過的裝置、UI 變更的前後截圖。

  如果碰到安全關鍵的部分（EEW 推估、警報門檻、通知路徑、背景定位），
  請額外說明你怎麼確認它沒有壞。
-->

## 檢查清單

- [ ] `tool/check/commits.sh origin/main..HEAD` 通過
      —— commit 訊息就是更新日誌，格式見 [commit.md](../commit.md)
- [ ] **一個 commit 一件事**（這條 gate 驗不了，靠自己和 review）
- [ ] `mise exec -- flutter analyze` 與 `mise exec -- flutter test` 通過
- [ ] 新的使用者可見字串都走 `AppLocalizations`，沒有寫死
- [ ] 有 UI 變更的話：用的是 `AppSpacing` / `AppRadius` / `AppMotion`，
      深色模式看過，文字對比度可接受
