### PR TITLE
feat(log): widen the dump budget to fit a debug session

### DIFF
--- a/lib/core/diagnostics/debug_dump.dart
+++ b/lib/core/diagnostics/debug_dump.dart
@@ -7,7 +7,7 @@ library;
 /// a chat window will show without collapsing. The diagnostics are the part
 /// that cannot be trimmed (every row answers a question somebody asks), so the
 /// log takes whatever is left.
-const int dumpLimit = 4000;
+const int dumpLimit = 39995;
 
 const String _diagnosticsHeading = '=== 除錯資訊 ===';
 const String _logHeading = '=== 日誌紀錄 ===';

--- a/lib/core/diagnostics/haste_api.dart
+++ b/lib/core/diagnostics/haste_api.dart
@@ -7,8 +7,9 @@ import 'package:dpip/core/diagnostics/dump_uploader.dart';
 /// Posts a dump and returns the URL to read it at.
 ///
 /// A paste rather than an attachment because of where these end up: a bug
-/// report in Discord or an issue, where 4000 characters of log pasted inline
-/// buries everything around it and an attached file is not read at all.
+/// report in Discord or an issue, where tens of thousands of characters of log
+/// pasted inline buries everything around it and an attached file is not read
+/// at all.
 class HasteApi implements DumpUploader {
   const HasteApi(this._client);
 

--- a/lib/shared/diagnostics/dump_action.dart
+++ b/lib/shared/diagnostics/dump_action.dart
@@ -22,8 +22,9 @@ import 'package:talker_flutter/talker_flutter.dart';
 ///
 /// The two halves answer different questions and a report needs both: the
 /// diagnostics say what this build and this device are, the log says what they
-/// just did. Pasting 4000 characters into a chat buries the conversation they
-/// are part of, so they go to a paste and only the link comes back.
+/// just did. Pasting tens of thousands of characters into a chat buries the
+/// conversation they are part of, so they go to a paste and only the link
+/// comes back.
 ///
 /// Returns true when a link was produced. Failures are reported to the user
 /// here and logged; the caller only has to stop showing its spinner.

--- a/test/core/diagnostics/debug_dump_test.dart
+++ b/test/core/diagnostics/debug_dump_test.dart
@@ -54,10 +54,11 @@ void main() {
   test('diagnostics are never cut to make room', () {
     // A partial diagnostic reads as a complete one and is answered as if it
     // were, which is worse than carrying no log at all.
-    final big = 'Version: 26w34b\n${'x' * 5000}';
+    // Sized past the limit so the log must be dropped for the diagnostics to fit.
+    final big = 'Version: 26w34b\n${'x' * (dumpLimit + 1000)}';
     final out = buildDump(diagnostics: big, logLines: lines(50));
     expect(out, contains('Version: 26w34b'));
-    expect(out, contains('x' * 5000));
+    expect(out, contains('x' * (dumpLimit + 1000)));
     expect(out, isNot(contains('line 0')));
   });
 

--- a/test/core/logging/log_benign_assert_test.dart
+++ b/test/core/logging/log_benign_assert_test.dart
@@ -2,7 +2,7 @@
 /// into the log that sheet belongs to — a debug assert from talker_flutter,
 /// which paints that sheet as a coloured box with bare `ListTile`s inside it.
 /// Nothing this app can fix, and nothing a user is affected by, but it filled
-/// the terminal, the log page and the 4000-character dump budget.
+/// the terminal, the log page and the dump budget.
 ///
 /// The tests here pin the two halves of the compromise: it is said once, so it
 /// is on the record, and it is said only once, so it cannot flood. A real error


### PR DESCRIPTION
New(zh-Hant): 診斷回報上限放寬，可附上更完整的日誌
New(en-US): the diagnostics report now carries a much longer log tail

<!--
  進行中的 PR 請開草稿（Draft）。

  收到 review 之後請避免 force push，否則審查者看不到你改了什麼。

  送出之前跑 `tool/commit.sh --push` —— CI 跑的就是同一份，在本機失敗比在 CI
  失敗快得多，而且 `.githooks/pre-push` 本來就會替你跑一次。

  **這份描述不會被任何 gate 檢查，也不會進 main。** 被檢查的是分支上每一則
  commit 訊息，進 main 的也是它們 —— 這個 repo 只開放 rebase 合併。所以要寫給
  未來的人看的東西，寫在 commit 訊息裡，不是這裡。
-->

## 這個 PR 做了什麼

<!-- 一句話講清楚。細節寫在 commit 訊息裡，不要寫在這裡。 -->

## 相關 issue

<!-- 「closes #1234」會在合併時自動關閉對應的 issue。 -->

- closes #

## 怎麼驗

<!--
  審查者要怎麼確認這是對的：重現步驟、測過的裝置、UI 變更的前後截圖。

  如果碰到安全關鍵的部分（EEW 推估、警報門檻、通知路徑、背景定位），
  請額外說明你怎麼確認它沒有壞。
-->

## 檢查清單

- [ ] `tool/check/commits.sh origin/main..HEAD` 通過
      —— commit 訊息就是更新日誌，格式見 [commit.md](../commit.md)
- [ ] **一個 commit 一件事**（這條 gate 驗不了，靠自己和 review）
- [ ] `mise exec -- flutter analyze` 與 `mise exec -- flutter test` 通過
- [ ] 新的使用者可見字串都走 `AppLocalizations`，沒有寫死
- [ ] 有 UI 變更的話：用的是 `AppSpacing` / `AppRadius` / `AppMotion`，
      深色模式看過，文字對比度可接受
