### PR TITLE
fix: keep the location dot above the township outline, and repair the rain legend

### DIFF
--- a/lib/features/home/presentation/widgets/home_map_backdrop.dart
+++ b/lib/features/home/presentation/widgets/home_map_backdrop.dart
@@ -68,6 +68,49 @@ class _HomeMapBackdropState extends State<HomeMapBackdrop>
   static const String _radarLayer = 'home-radar-lyr';
   static const double _radarOpacity = 0.85;
 
+  /// Finds the lowest layer belonging to MapLibre Android's native location
+  /// puck in the *live* style, or null if it isn't there.
+  ///
+  /// Android and iOS need opposite handling here, and this one query gives
+  /// both the right answer without a platform branch:
+  ///
+  /// - **Android**: the puck is not an overlay drawn above the map — it is
+  ///   itself a handful of runtime style layers (ids like
+  ///   `mapbox-location-shadow-layer`, `…-foreground-layer`, …), so it does
+  ///   not automatically stay above whatever this backdrop adds afterward.
+  ///   Hardcoding one of those names is fragile: the SDK picks between a
+  ///   legacy multi-layer renderer and a newer single "location-indicator"
+  ///   layer internally, not through anything this plugin's Dart API
+  ///   exposes, so a name that matches today's build can silently stop
+  ///   matching after an SDK bump. Querying the live stack for whichever id
+  ///   actually contains "location" survives that. [style.getLayers()][1] —
+  ///   what `getLayerIds()` wraps — orders bottom to top, so the first match
+  ///   is the bottom of the puck's own layer group; anchoring
+  ///   [_addSelectedLayers] below *that* keeps it under every sub-layer the
+  ///   puck is made of, however many there are.
+  /// - **iOS**: this fork's `MapLibreMapController.swift` just flips
+  ///   `MLNMapView.showsUserLocation` — the puck is a native
+  ///   `MLNUserLocationAnnotationView`, composited over the rendered map by
+  ///   the SDK itself, never a style layer. No id here will ever contain
+  ///   "location", so this correctly returns null and [_addSelectedLayers]
+  ///   falls back to the plain top-of-stack add — which is already right on
+  ///   iOS, since nothing in the style's layer order can cover an annotation
+  ///   that isn't part of that stack in the first place.
+  ///
+  /// [1]: MapLibre Android's `Style.getLayers()`.
+  Future<String?> _locationPuckLayerId(MapLibreMapController controller) async {
+    try {
+      final ids = await controller.getLayerIds();
+      for (final id in ids) {
+        if (id is String && id.toLowerCase().contains('location')) return id;
+      }
+      Log.debug('Home map: no location layer found in $ids');
+    } catch (e, st) {
+      Log.handle(e, st, 'Home map: getLayerIds failed');
+    }
+    return null;
+  }
+
   /// How far the selected township's bounds are pushed outward before fitting —
   /// a fraction of the box's span added to every side — so it frames with
   /// surrounding context instead of edge-to-edge. Fitting the (expanded) bounds
@@ -311,6 +354,7 @@ class _HomeMapBackdropState extends State<HomeMapBackdrop>
     List<Object> filter,
   ) async {
     await _removeLayerQuietly(controller, _selectedLineLayer);
+    final belowLayerId = await _locationPuckLayerId(controller);
     await controller.addLineLayer(
       'exptech',
       _selectedLineLayer,
@@ -319,6 +363,7 @@ class _HomeMapBackdropState extends State<HomeMapBackdrop>
       sourceLayer: 'town',
       filter: filter,
       enableInteraction: false,
+      belowLayerId: belowLayerId,
     );
   }
 

--- a/lib/features/map/presentation/layers/rain_layer.dart
+++ b/lib/features/map/presentation/layers/rain_layer.dart
@@ -95,6 +95,12 @@ class RainMapLayer
   @override
   bool get bandedColors => true;
 
+  /// The legend draws as a gradient, unlike the dots and sheet reading above —
+  /// matching the QPESUMS forecast legend's look, since both are precipitation
+  /// scales shown on the same map.
+  @override
+  bool get legendBanded => false;
+
   @override
   double? valueOf(RainObservation observation) =>
       interval.value.valueOf(observation);

--- a/lib/features/map/presentation/layers/weather_station_layer.dart
+++ b/lib/features/map/presentation/layers/weather_station_layer.dart
@@ -68,9 +68,18 @@ abstract class WeatherStationLayer<
   /// value between two stops genuinely lies between two colours. Accumulations
   /// do not — the published rainfall scale is a table of categories, and a dot
   /// blended halfway between the 70 mm and 90 mm bands claims a precision the
-  /// band structure denies. Banded layers get a MapLibre `step`, [stepColor]
-  /// in the sheet, and a hard-edged legend, so all three agree.
+  /// band structure denies. Banded layers get a MapLibre `step` and
+  /// [stepColor] in the sheet — see [legendBanded] for the legend, which does
+  /// not always follow this.
   bool get bandedColors => false;
+
+  /// Whether the legend draws hard bands rather than a gradient.
+  ///
+  /// Defaults to [bandedColors], but a subclass may split the two: rain keeps
+  /// its dots and sheet reading banded (the CWA scale is genuinely
+  /// categorical) while drawing its legend as a gradient, to read
+  /// consistently with the other precipitation layers on the map.
+  bool get legendBanded => bandedColors;
 
   /// Whether to draw the value-coloured dot. A subclass may replace it with its
   /// own symbology (e.g. wind arrows) by returning false.
@@ -231,7 +240,7 @@ abstract class WeatherStationLayer<
     final scale = ColorScaleLegend(
       stops: colorStops,
       unit: unit,
-      banded: bandedColors,
+      banded: legendBanded,
     );
     final child = header == null
         ? scale

--- a/lib/features/map/presentation/layers/weather_station_layer.dart
+++ b/lib/features/map/presentation/layers/weather_station_layer.dart
@@ -234,8 +234,14 @@ abstract class WeatherStationLayer<
   }
 
   /// Colour scale from [colorStops] + [unit], with an optional [legendHeader].
-  @override
-  Widget buildLegend(BuildContext context) {
+  ///
+  /// Built inside the [ListenableBuilder]'s callback, not before it: rain's
+  /// header and scale both read live state ([legendHeader]'s interval,
+  /// [colorStops]' colour scale), so building them once and handing
+  /// [ListenableBuilder] the finished card would freeze the legend at
+  /// whichever window was selected when it first appeared — every later
+  /// `chromeListenable` notify would just replay that same stale widget.
+  Widget _buildLegendCard(BuildContext context) {
     final header = legendHeader(context);
     final scale = ColorScaleLegend(
       stops: colorStops,
@@ -253,11 +259,18 @@ abstract class WeatherStationLayer<
               scale,
             ],
           );
-    final card = MapLegendCard(child: child);
+    return MapLegendCard(child: child);
+  }
+
+  @override
+  Widget buildLegend(BuildContext context) {
     final listenable = chromeListenable;
     return listenable == null
-        ? card
-        : ListenableBuilder(listenable: listenable, builder: (_, _) => card);
+        ? _buildLegendCard(context)
+        : ListenableBuilder(
+            listenable: listenable,
+            builder: (context, _) => _buildLegendCard(context),
+          );
   }
 
   @override

--- a/test/features/map/rain_legend_test.dart
+++ b/test/features/map/rain_legend_test.dart
@@ -2,16 +2,23 @@
 /// inside the collapsed chip, whose `AnimatedSize` lays out with unbounded
 /// width.
 ///
-/// Guards two regressions that together made the 雨量 legend useless:
+/// Two things guarded here:
 ///
-/// 1. The banded label column (`_BandBoundaryLabels`) was a bare `Stack` in a
-///    Row, and a Stack refuses unbounded width — expanding the legend threw a
-///    layout assertion every frame and it never appeared. The column now
-///    measures the widest boundary label and carries its own width.
-/// 2. The band strip's `ColoredBox` cells have no intrinsic width, so under
-///    the default `Column` cross axis they collapsed to zero and the strip
-///    was invisible — the boundary numbers had no colours beside them. The
-///    band column now stretches across the swatch width.
+/// 1. [RainMapLayer]'s legend draws as a gradient — like the QPESUMS forecast
+///    legend — even though the dots and sheet reading underneath stay banded
+///    (the CWA scale is genuinely categorical; only the legend's look
+///    changed, via `WeatherStationLayer.legendBanded`).
+/// 2. `ColorScaleLegend(banded: true)` — the hard-edged rendering rain no
+///    longer uses for its own legend, but which the widget still supports for
+///    a genuinely categorical scale — must keep working inside this same
+///    unbounded-width chip. This guards two regressions that together once
+///    made a banded legend useless: the boundary-label column is a `Stack` in
+///    a `Row`, and a `Stack` refuses unbounded width, so expanding the legend
+///    threw a layout assertion every frame and it never appeared; and the
+///    band strip's `ColoredBox` cells have no intrinsic width, so under the
+///    default `Column` cross axis they collapsed to zero and the strip was
+///    invisible while the boundary numbers kept rendering with no colour
+///    beside them.
 library;
 
 import 'package:dpip/core/error/result.dart';
@@ -46,65 +53,122 @@ class _StubRainRepository implements MeteorRainRepository {
       Ok(RainTrend(id: id, range: range, times: const [], rain: const []));
 }
 
-void main() {
-  testWidgets(
-    'the banded legend expands inside the chip without layout exceptions',
-    (tester) async {
-      final layer = RainMapLayer(_StubRainRepository());
-      await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          locale: const Locale('zh'),
-          home: Scaffold(
-            body: Builder(
-              builder: (context) => Stack(
-                children: [
-                  Positioned(
-                    top: 0,
-                    left: 0,
-                    child: SafeArea(
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: CollapsibleMapLegend(
-                          key: ValueKey(layer.id),
-                          legend: layer.buildLegend(context),
-                        ),
-                      ),
+/// Pumps the legend built by [legendBuilder] inside the same collapsed-chip /
+/// `AnimatedSize` context the map actually uses, then expands it.
+Future<void> _pumpExpanded(
+  WidgetTester tester,
+  Widget Function(BuildContext) legendBuilder,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('zh'),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Stack(
+            children: [
+              Positioned(
+                top: 0,
+                left: 0,
+                child: SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: CollapsibleMapLegend(
+                      key: const ValueKey('legend-under-test'),
+                      legend: legendBuilder(context),
                     ),
                   ),
-                ],
+                ),
               ),
-            ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+
+  final semantics = tester.ensureSemantics();
+  await tester.pump();
+  await tester.tap(find.byIcon(Icons.legend_toggle));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 500));
+  await tester.pump(const Duration(milliseconds: 500));
+  semantics.dispose();
+}
+
+void main() {
+  testWidgets('the rain legend draws a gradient, not hard bands', (
+    tester,
+  ) async {
+    final layer = RainMapLayer(_StubRainRepository());
+    await _pumpExpanded(tester, layer.buildLegend);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ColorScaleLegend), findsOneWidget);
+    expect(find.byType(MapLegendCard), findsOneWidget);
+
+    // No banded swatch cells — the gradient path paints the scale as a single
+    // `Container` with a `LinearGradient`, not a column of opaque
+    // `ColoredBox`es. (An incidental translucent `ColoredBox` from the
+    // surrounding chip chrome is not one of those.)
+    final opaqueBandCells = tester
+        .widgetList<ColoredBox>(
+          find.descendant(
+            of: find.byType(MapLegendCard),
+            matching: find.byType(ColoredBox),
+          ),
+        )
+        .where((cb) => cb.color.a == 1.0);
+    expect(opaqueBandCells, isEmpty);
+
+    final gradientContainers = tester
+        .widgetList<Container>(
+          find.descendant(
+            of: find.byType(MapLegendCard),
+            matching: find.byType(Container),
+          ),
+        )
+        .where((c) => (c.decoration as BoxDecoration?)?.gradient != null)
+        .toList();
+    expect(gradientContainers, hasLength(1));
+    final gradient = gradientContainers.single.decoration as BoxDecoration;
+    expect((gradient.gradient as LinearGradient).colors, hasLength(17));
+  });
+
+
+  testWidgets(
+    'ColorScaleLegend(banded: true) still expands inside the chip without '
+    'layout exceptions',
+    (tester) async {
+      await _pumpExpanded(
+        tester,
+        (_) => const MapLegendCard(
+          child: ColorScaleLegend(
+            unit: 'mm',
+            banded: true,
+            stops: [
+              (0, '#c2c2c2'),
+              (1, '#a0fffa'),
+              (2, '#00cdff'),
+              (6, '#0096ff'),
+            ],
           ),
         ),
       );
 
-      // The chip should be visible.
-      expect(find.byIcon(Icons.legend_toggle), findsOneWidget);
-
-      // The map's legend chip lays out in an unbounded-width context
-      // (AnimatedSize) — the banded label column must carry its own width.
-      // Semantics on, like the running app under VoiceOver: the broken layout
-      // also wedged the semantics flush, so cover that path too.
-      final semantics = tester.ensureSemantics();
-      await tester.pump();
-
-      // Expand it.
-      await tester.tap(find.byIcon(Icons.legend_toggle));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pump(const Duration(milliseconds: 500));
-
-      final errors = tester.takeException();
-      expect(errors, isNull, reason: 'no exception while rendering legend');
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'no exception while rendering legend',
+      );
       expect(find.byType(ColorScaleLegend), findsOneWidget);
-      expect(find.byType(MapLegendCard), findsOneWidget);
 
-      // Every one of the 17 CWA bands must actually paint: the band cells are
-      // plain ColoredBoxes (no intrinsic width), so a non-stretched column
-      // collapses them to zero width and the strip vanishes while the numbers
-      // stay. Assert the opaque cells inside the card are 17, each 8 px wide.
+      // Every band must actually paint: the band cells are plain
+      // `ColoredBox`es (no intrinsic width), so a non-stretched column
+      // collapses them to zero width and the strip vanishes while the
+      // numbers stay. Assert the opaque cells inside the card are all 4,
+      // each 8 px wide.
       final swatchFinder = find.descendant(
         of: find.byType(MapLegendCard),
         matching: find.byType(ColoredBox),
@@ -113,10 +177,9 @@ void main() {
           .widgetList<ColoredBox>(swatchFinder)
           .where((cb) => cb.color.a == 1.0)
           .toList();
-      expect(opaque, hasLength(17));
+      expect(opaque, hasLength(4));
       final firstSwatch = tester.renderObject<RenderBox>(swatchFinder.at(1));
       expect(firstSwatch.size.width, 8);
-      semantics.dispose();
     },
   );
 }

--- a/test/features/map/rain_legend_test.dart
+++ b/test/features/map/rain_legend_test.dart
@@ -24,6 +24,7 @@ library;
 import 'package:dpip/core/error/result.dart';
 import 'package:dpip/features/map/presentation/layers/rain_layer.dart';
 import 'package:dpip/features/weather/domain/meteor_rain_repository.dart';
+import 'package:dpip/features/weather/domain/rain_interval.dart';
 import 'package:dpip/features/weather/domain/rain_snapshot.dart';
 import 'package:dpip/features/weather/domain/rain_trend.dart';
 import 'package:dpip/features/weather/domain/weather_station.dart';
@@ -136,6 +137,29 @@ void main() {
     expect((gradient.gradient as LinearGradient).colors, hasLength(17));
   });
 
+  testWidgets(
+    "the legend's header follows a later interval change, not just its "
+    'first build',
+    (tester) async {
+      final layer = RainMapLayer(_StubRainRepository());
+      await _pumpExpanded(tester, layer.buildLegend);
+
+      // Default window is 1 時 (see RainMapLayer.interval's doc).
+      expect(find.text('1 時'), findsOneWidget);
+      expect(find.text('今日'), findsNothing);
+
+      // buildLegend wraps its header + scale in a ListenableBuilder driven by
+      // chromeListenable (interval + colorScale). Building that header and
+      // scale *before* handing them to the builder — rather than inside its
+      // callback — would freeze the legend at whatever was selected when it
+      // first appeared, silently ignoring every later interval change.
+      await layer.setInterval(RainInterval.now);
+      await tester.pump();
+
+      expect(find.text('今日'), findsOneWidget);
+      expect(find.text('1 時'), findsNothing);
+    },
+  );
 
   testWidgets(
     'ColorScaleLegend(banded: true) still expands inside the chip without '


### PR DESCRIPTION
<!--
  進行中的 PR 請開草稿（Draft）。

  收到 review 之後請避免 force push，否則審查者看不到你改了什麼。

  送出之前跑 `tool/commit.sh --push` —— CI 跑的就是同一份，在本機失敗比在 CI
  失敗快得多，而且 `.githooks/pre-push` 本來就會替你跑一次。

  **這份描述不會被任何 gate 檢查，也不會進 main。** 被檢查的是分支上每一則
  commit 訊息，進 main 的也是它們 —— 這個 repo 只開放 rebase 合併。所以要寫給
  未來的人看的東西，寫在 commit 訊息裡，不是這裡。
-->

## 這個 PR 做了什麼

三則 fix：

- **Android：定位圓點不再被選取的鄉鎮框線蓋住。** 首頁地圖的選取框線原本
  「永遠在最上層」，會蓋住 MapLibre Android 的定位圓點（puck）；現在改為
  查詢 live style 找到 puck 自己的 layer 疊加層，把框線錨在它之下；找不到
  就退回原本的置頂行為（iOS 不受影響）。
- **雨量圖例改為漸層顯示。** 與雷達預報圖例一致——雨量點與數值讀數仍維持
  分級色（CWA 的降雨尺度本來就是類別表），只有圖例外觀統一成漸層。
- **切換觀測時段後圖例跟著更新。** 圖例的標題與色標改在 `ListenableBuilder`
  的回呼內重建，不再卡在圖例第一次出現時選的時段。

## 相關 issue

- closes #

## 怎麼驗

- 圖例：開啟雨量圖層，展開圖例 chip——確認漸層外觀；切換 1 時 / 今日 / 累積
  時段，圖例標題應隨之更新。
- 定位圓點：Android 上授予定位權限，在首頁地圖選取一個鄉鎮，確認 GPS 圓點
  仍顯示在框線之上；iOS 上確認行為不變（原本就沒有被蓋住的問題，走 fallback）。
- `tool/check.sh` 全綠：commit gate 3 則 OK、analyze 通過、1726 則測試全過。

## 檢查清單

- [x] `tool/check/commits.sh origin/main..HEAD` 通過
      —— commit 訊息就是更新日誌，格式見 [commit.md](../commit.md)
- [x] **一個 commit 一件事**（這條 gate 驗不了，靠自己和 review）
- [x] `mise exec -- flutter analyze` 與 `mise exec -- flutter test` 通過
- [x] 新的使用者可見字串都走 `AppLocalizations`，沒有寫死
- [ ] 有 UI 變更的話：用的是 `AppSpacing` / `AppRadius` / `AppMotion`，
      深色模式看過，文字對比度可接受
