### PR TITLE
build: make toolchain checks portable on Windows

### DIFF
--- a/tool/check/tooling.sh
+++ b/tool/check/tooling.sh
@@ -75,7 +75,20 @@ done
 while IFS= read -r script; do
   bash -n "$script" 2>/dev/null || report "$script: does not parse"
 
-  [[ -x $script ]] || report "$script: is not executable (chmod +x)"
+  case "${OSTYPE:-}" in
+    msys*|cygwin*)
+      # Windows filesystems do not expose Unix executable bits reliably.
+      # Git's index is authoritative for the mode that macOS, Linux, and CI
+      # receive after checkout.
+      mode="$(git ls-files --stage -- "$script" | awk 'NR == 1 { print $1 }')"
+      [[ $mode == 100755 ]] ||
+        report "$script: is not executable in git (git update-index --chmod=+x)"
+      ;;
+    *)
+      [[ -x $script ]] ||
+        report "$script: is not executable (chmod +x)"
+      ;;
+  esac
 
   head -1 "$script" | grep -q '^#!/usr/bin/env bash$' ||
     [[ $script == tool/dev/_lib.sh ]] ||

--- a/tool/dev/_lib.sh
+++ b/tool/dev/_lib.sh
@@ -80,9 +80,48 @@ EOF
   # is identical either way.
   local owned
   owned="$(cd "$root" && mise where flutter 2>/dev/null || true)"
-  if [[ -z $owned || $resolved != "$owned"/* ]]; then
+  if [[ -z $owned ]]; then
     printf '\n  flutter resolves to %s\n' "$resolved" >&2
-    printf '  which is not inside mise (%s).\n\n' "${owned:-not installed}" >&2
+    printf '  but mise reports that flutter is not installed.\n\n' >&2
+    printf '  Run `mise install` from %s.\n\n' "$root" >&2
+    exit 1
+  fi
+
+  local resolved_for_compare="$resolved"
+  local owned_for_compare="$owned"
+
+  case "${OSTYPE:-}" in
+    msys*|cygwin*)
+      # Git Bash/MSYS and Cygwin may express one Windows path as C:\Users\...
+      # in one command and /c/Users/... in another. Normalize both to the same
+      # mixed Windows form before checking ownership; do not skip the check.
+      if ! command -v cygpath >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
+
+  cygpath is required to verify that flutter belongs to mise, but it could not
+  be found in this MSYS/Cygwin environment.
+
+EOF
+        exit 1
+      fi
+
+      resolved_for_compare="$(cygpath -am -- "$resolved")"
+      owned_for_compare="$(cygpath -am -- "$owned")"
+
+      # Windows paths are case-insensitive. Mixed form uses forward slashes,
+      # and removing a trailing slash keeps the prefix test unambiguous.
+      resolved_for_compare="${resolved_for_compare,,}"
+      owned_for_compare="${owned_for_compare%/}"
+      owned_for_compare="${owned_for_compare,,}"
+      ;;
+    *)
+      owned_for_compare="${owned_for_compare%/}"
+      ;;
+  esac
+
+  if [[ $resolved_for_compare != "$owned_for_compare"/* ]]; then
+    printf '\n  flutter resolves to %s\n' "$resolved" >&2
+    printf '  which is not inside mise (%s).\n\n' "$owned" >&2
     printf '  Run `mise install` from %s.\n\n' "$root" >&2
     exit 1
   fi


### PR DESCRIPTION
<!--
  進行中的 PR 請開草稿（Draft）。

  收到 review 之後請避免 force push，否則審查者看不到你改了什麼。

  送出之前跑 `tool/commit.sh --push` —— CI 跑的就是同一份，在本機失敗比在 CI
  失敗快得多，而且 `.githooks/pre-push` 本來就會替你跑一次。

  **這份描述不會被任何 gate 檢查，也不會進 main。** 被檢查的是分支上每一則
  commit 訊息，進 main 的也是它們 —— 這個 repo 只開放 rebase 合併。所以要寫給
  未來的人看的東西，寫在 commit 訊息裡，不是這裡。
-->

## 這個 PR 做了什麼

讓 mise 工具鏈 ownership 與 executable-bit 檢查可在 Windows Git Bash 正確運作，同時維持 macOS 與 Linux 的既有檢查。
<!-- 一句話講清楚。細節寫在 commit 訊息裡，不要寫在這裡。 -->

## 相關 issue

<!-- 「closes #1234」會在合併時自動關閉對應的 issue。 -->

- closes #

## 怎麼驗

在 Windows Git Bash 執行：

```sh
mise which flutter
mise where flutter
tool/check/tooling.sh
mise exec -- flutter analyze
tool/run.sh
```
<!--
  審查者要怎麼確認這是對的：重現步驟、測過的裝置、UI 變更的前後截圖。

  如果碰到安全關鍵的部分（EEW 推估、警報門檻、通知路徑、背景定位），
  請額外說明你怎麼確認它沒有壞。
-->

## 檢查清單

- [ ] `tool/check/commits.sh origin/main..HEAD` 通過
      —— commit 訊息就是更新日誌，格式見 [commit.md](../commit.md)
- [ ] **一個 commit 一件事**（這條 gate 驗不了，靠自己和 review）
- [ ] `mise exec -- flutter analyze` 與 `mise exec -- flutter test` 通過
- [ ] 新的使用者可見字串都走 `AppLocalizations`，沒有寫死
- [ ] 有 UI 變更的話：用的是 `AppSpacing` / `AppRadius` / `AppMotion`，
      深色模式看過，文字對比度可接受
