### PR TITLE
fix(bug-tracker): follow the tracker to its v1 endpoint

### DIFF
--- a/lib/features/bug_tracker/data/bug_api.dart
+++ b/lib/features/bug_tracker/data/bug_api.dart
@@ -3,6 +3,11 @@ library;
 
 import 'package:dpip/core/network/api_client.dart';
 
+/// The forum tag that marks a thread as about THIS app. A routing marker, not
+/// a category — it is filtered on, both by the server and again here, and
+/// never rendered.
+const String appBugTag = 'dpip';
+
 /// Reads the reported-bug threads from the tracker host.
 ///
 /// Absolute URL on purpose: `bamboo.exptech.dev` is a single host outside the
@@ -14,13 +19,18 @@ class BugApi {
 
   final ApiClient _client;
 
-  static const String _base = 'https://bamboo.exptech.dev/api/dc/bug';
+  static const String _base = 'https://bamboo.exptech.dev/api/v1/dc/bug';
 
   /// Every thread in the index, capped at 50 so the payload stays bounded as
   /// the tracker grows. The query rides the URL, so the ETag store keys it as
   /// its own resource.
+  ///
+  /// `tag` asks the server for this app's threads only. It matters for the cap
+  /// as much as for correctness: the tracker is shared with other products, so
+  /// an unfiltered page of 50 spends some of its rows on threads this app then
+  /// throws away — measured against the live index, 3 of 50.
   Future<dynamic> list() =>
-      _client.getAbsolute(_base, query: const {'limit': 50});
+      _client.getAbsolute(_base, query: const {'limit': 50, 'tag': appBugTag});
 
   /// One thread with its replies.
   Future<dynamic> thread(int id) => _client.getAbsolute('$_base/$id');

--- a/lib/features/bug_tracker/data/bug_repository_impl.dart
+++ b/lib/features/bug_tracker/data/bug_repository_impl.dart
@@ -9,13 +9,6 @@ import 'package:dpip/features/bug_tracker/domain/bug_thread.dart';
 import 'package:dpip/features/bug_tracker/domain/bug_repository.dart';
 import 'package:flutter/foundation.dart';
 
-/// The forum tag that marks a thread as about THIS app. A routing marker, not
-/// a category — it is filtered on and never rendered.
-///
-/// In canonical form: see [canonicalBugTag] for why the two endpoints disagree
-/// about how they spell it.
-const String appBugTag = 'dpip';
-
 class BugRepositoryImpl implements BugRepository {
   const BugRepositoryImpl(this._api);
 
@@ -44,22 +37,20 @@ String _normalise(String body) => body.replaceAllMapped(
   (match) => match.group(1) ?? match.input,
 );
 
-/// The two tracker endpoints spell the same tag two different ways.
+/// A tag as the app matches it: the forum's slug, lower-cased.
 ///
-/// The index sends the forum's slugs — `["dpip", "bug"]`. The detail endpoint
-/// still reflects Discord's raw forum labels, which are bilingual — `["臭蟲
-/// bug", "DPIP", "已解決 fixed"]`. Left alone, one thread carries `bug` in the
-/// list and `臭蟲` on its own page, and the routing marker matches `dpip` in
-/// one place and `DPIP` in the other — which drops every thread from the
-/// index, because nothing equals `DPIP` once the server started sending slugs.
+/// Both endpoints now send slugs — `["bug", "dpip", "fixed"]` — verified
+/// across the index and ten detail replies covering every tag in the
+/// vocabulary. They did not always agree: the detail endpoint used to reflect
+/// Discord's raw bilingual labels (`臭蟲 bug`, `DPIP`, `已解決 fixed`), so this
+/// took a label's English tail to reconcile the two. That split is gone with
+/// the behaviour it compensated for; a tag with a space in it is now a tag
+/// with a space in it.
 ///
-/// The slug is the canonical form, so a bilingual label yields its English
-/// tail. `臭蟲 bug` → `bug`, `DPIP` → `dpip`, `bug` → `bug`.
-String canonicalBugTag(String tag) {
-  final trimmed = tag.trim();
-  final space = trimmed.lastIndexOf(' ');
-  return (space < 0 ? trimmed : trimmed.substring(space + 1)).toLowerCase();
-}
+/// The lower-casing stays. It is what the routing marker actually needed —
+/// `DPIP` had to equal `dpip` or every thread fell out of the index — and it
+/// is one comparison against a regression whose other failure mode is silent.
+String canonicalBugTag(String tag) => tag.trim().toLowerCase();
 
 List<String> _canonicalTags(Object? raw) {
   if (raw is! List) return const [];
@@ -145,8 +136,11 @@ List<BugThread> parseBugThreads(Object? body) {
   ];
   // `dpip` is the forum's routing marker: threads without it are not about
   // this app (other products share the tracker), so they never reach the
-  // index. Locked threads are staff-side conversations — same. Matched in
-  // canonical form, because the marker arrives spelt both ways.
+  // index. `BugApi.list` already asks the server for that tag, so this is the
+  // backstop rather than the mechanism — a server that stops honouring the
+  // query would otherwise put another product's threads in this list with no
+  // other symptom. Locked threads are staff-side conversations, which the
+  // query cannot express at all.
   threads.removeWhere(
     (thread) =>
         thread.locked || !thread.tags.map(canonicalBugTag).contains(appBugTag),

--- a/test/features/bug_tracker/bug_repository_test.dart
+++ b/test/features/bug_tracker/bug_repository_test.dart
@@ -2,10 +2,11 @@
 /// live tracker's updated contract (2026-08-27): a `users` directory keyed by
 /// Discord snowflake plus `threads`/`msg` entries that reference it by id.
 ///
-/// The two endpoints spell tags differently — the index sends the forum's
-/// slugs, the detail endpoint still reflects Discord's bilingual labels — so
-/// the fixtures deliberately use both forms and both must canonicalise the
-/// same way.
+/// Both endpoints send the forum's slugs, lower-case (`["bug", "dpip"]`). The
+/// detail endpoint used to reflect Discord's bilingual labels instead; the
+/// fixtures still put a upper-case marker through the parser, because that is
+/// the spelling whose failure is silent — a routing tag that stops matching
+/// empties the whole list rather than mislabelling one badge.
 library;
 
 import 'package:dpip/features/bug_tracker/data/bug_repository_impl.dart';
@@ -50,14 +51,14 @@ void main() {
     );
   });
 
-  test('the index accepts the detail endpoint\'s bilingual labels too', () {
+  test('a tag is matched by its slug, whatever case it arrives in', () {
     final threads = parseBugThreads({
       'users': {_chenId: _user(_chenId, '陳')},
       'threads': [
         {
           'threads_id': 1,
           'title': 't',
-          'tags': ['DPIP', '臭蟲 bug', '已解決 fixed'],
+          'tags': ['DPIP', 'Bug', 'fixed'],
           'body': 'b',
           'author': _chenId,
           'created_at': 1787511150,
@@ -66,8 +67,9 @@ void main() {
       ],
     });
 
-    // Canonical form is the slug, so the English tail wins and the routing
-    // marker matches whichever way the server spelt it.
+    // The marker matched despite its case (the thread survived at all), and
+    // the categories come through lower-cased, which is the form the badge
+    // table is keyed by.
     expect(threads.single.tags, ['bug', 'fixed']);
   });
 


### PR DESCRIPTION
Fix(zh-Hant): 修正已回報錯誤讀不到內容，並改由伺服器過濾，清單不再被其他產品的討論串佔位
Fix(en-US): fix the reported-bugs list failing to load, and let the server filter it so other products' threads no longer take up slots

<!--
  進行中的 PR 請開草稿（Draft）。

  收到 review 之後請避免 force push，否則審查者看不到你改了什麼。

  送出之前跑 `tool/commit.sh --push` —— CI 跑的就是同一份，在本機失敗比在 CI
  失敗快得多，而且 `.githooks/pre-push` 本來就會替你跑一次。

  **這份描述不會被任何 gate 檢查，也不會進 main。** 被檢查的是分支上每一則
  commit 訊息，進 main 的也是它們 —— 這個 repo 只開放 rebase 合併。所以要寫給
  未來的人看的東西，寫在 commit 訊息裡，不是這裡。
-->

## 這個 PR 做了什麼

<!-- 一句話講清楚。細節寫在 commit 訊息裡，不要寫在這裡。 -->

## 相關 issue

<!-- 「closes #1234」會在合併時自動關閉對應的 issue。 -->

- closes #

## 怎麼驗

<!--
  審查者要怎麼確認這是對的：重現步驟、測過的裝置、UI 變更的前後截圖。

  如果碰到安全關鍵的部分（EEW 推估、警報門檻、通知路徑、背景定位），
  請額外說明你怎麼確認它沒有壞。
-->

## 檢查清單

- [ ] `tool/check/commits.sh origin/main..HEAD` 通過
      —— commit 訊息就是更新日誌，格式見 [commit.md](../commit.md)
- [ ] **一個 commit 一件事**（這條 gate 驗不了，靠自己和 review）
- [ ] `mise exec -- flutter analyze` 與 `mise exec -- flutter test` 通過
- [ ] 新的使用者可見字串都走 `AppLocalizations`，沒有寫死
- [ ] 有 UI 變更的話：用的是 `AppSpacing` / `AppRadius` / `AppMotion`，
      深色模式看過，文字對比度可接受
