### PR TITLE
test(location): commit the track fixture once, not per fix

### DIFF
--- a/test/core/geo/location_track_test.dart
+++ b/test/core/geo/location_track_test.dart
@@ -28,6 +28,16 @@ void _writeFixture(String path, List<(int, double, double)> fixes) {
     'lat INTEGER NOT NULL, lng INTEGER NOT NULL)',
   );
 
+  // One transaction for the whole fixture. The loop below writes a row at a
+  // time because that is what the native stores do, but in WAL mode each of
+  // those is its own commit and its own fsync — 20 000 of them for the
+  // compactness test at the bottom of this file. A local SSD answers an fsync
+  // in tens of microseconds and a shared CI runner's disk in a millisecond or
+  // two, which is the whole distance between a one-second test here and the
+  // thirty-second timeout that took `main` red. Batching moves when the pages
+  // reach the disk, not what is in them: the file comes out at exactly the
+  // same 282 624 bytes, so the byte-per-fix budget still measures the encoding.
+  db.execute('BEGIN');
   for (final (time, latitude, longitude) in fixes) {
     final lat = (latitude * _scale).round();
     final lng = (longitude * _scale).round();
@@ -47,6 +57,7 @@ void _writeFixture(String path, List<(int, double, double)> fixes) {
       previous == null ? lng : lng - previous.$3,
     ]);
   }
+  db.execute('COMMIT');
   db.close();
 }
 


### PR DESCRIPTION
## 這個 PR 做了什麼

把 `location_track_test.dart` 的 fixture 寫入包進單一 transaction，讓兩萬列不再是兩萬次 fsync。

## 相關 issue

- closes #

## 怎麼驗

`main` 的 CI 在 [33449700473](https://github.com/ExpTechTW/DPIP/actions/runs/33449700473) 掛掉，只紅一項：

```
❌ test/core/geo/location_track_test.dart: the encoding stays compact
   TimeoutException after 0:00:30
```

二十分鐘前的那次跑同樣的程式碼是綠的，而測試檔和 `LocationTrack` 從寫出來到現在都沒有動過。所以不是壞掉，是本來就貼著上限。

`_writeFixture` 一次寫一列，因為原生的 `LocationTrackStore` 就是這樣寫的。但在 WAL 模式下每一列都是自己的 commit、自己的 fsync，而底下那個 compactness 測試要它寫兩萬列。本機 SSD 一次 fsync 幾十微秒，共用的 CI runner 磁碟一到兩毫秒，20000 乘上 1.5 毫秒剛好就是那三十秒。

包成一個 transaction 只改變頁面什麼時候落盤，不改變裡面裝什麼。改前改後各量一次：

| | 檔案大小 | bytes/fix |
|---|---|---|
| 每列各自 commit | 282,624 | 14.1312 |
| 單一 transaction | 282,624 | 14.1312 |

一個位元組都沒差，所以 `lessThan(20)` 仍然在量編碼本身，有人把絕對值存回去時照樣會失敗。

單獨跑該測試，暖機後各兩次（`flutter test` 啟動地板約 2.3 秒）：

| | 第一次 | 第二次 |
|---|---|---|
| 每列各自 commit | 3.27s | 3.44s |
| 單一 transaction | 2.58s | 2.53s |

測試本體從約 1.05 秒降到約 0.2 秒，縮掉的正是隨磁碟延遲放大的那一項。

順帶掃過整個 test 樹：只有這個檔案會開磁碟上的 sqlite，另一個 `test/core/storage/memory_db.dart` 是純記憶體的 helper，沒有 fsync。全套 1779 項測試裡最慢的一項是 2.1 秒，離 30 秒還很遠，這類逾時目前沒有第二處。

## 檢查清單

- [x] `tool/check/commits.sh origin/main..HEAD` 通過
- [x] **一個 commit 一件事**
- [x] `tool/dev/analyze.sh` 與 `tool/dev/test.sh` 通過（`tool/commit.sh` 全綠，1767 項）
- [x] 沒有新的使用者可見字串（只動測試）
- [x] 沒有 UI 變更
